### PR TITLE
Removed chunk size warning from vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ const config = defineConfig({
         rollupOptions: {
             external: ['fs', 'os', 'child_process', 'util'], // For build
         },
+        chunkSizeWarningLimit: NaN // Not needed for a desktop app
     },
     plugins: [
         vuePlugin({


### PR DESCRIPTION
As for my previous pull request, this pull request only removed the chunk size warning limit. It's a small change but a nice one imo