### PR TITLE
Disallow multiple WinBoat instances.

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, session } from 'electron';
+import { app, BrowserWindow, ipcMain, session, dialog } from 'electron';
 import { join } from 'path';
 import { initialize, enable } from '@electron/remote/main';
 
@@ -8,7 +8,14 @@ let mainWindow: BrowserWindow | null = null;
 
 function createWindow() {
     if(!app.requestSingleInstanceLock()) {
-        app.quit();
+        // @ts-ignore property "window" is optional, see: [dialog.showMessageBoxSync](https://www.electronjs.org/docs/latest/api/dialog#dialogshowmessageboxsyncwindow-options)
+        dialog.showMessageBoxSync(null, {
+            type: "error",
+            buttons: ["Close"],
+            title: "WinBoat",
+            message: "An instance of WinBoat is already running.\n\tMultiple Instances are not allowed."
+        });
+        app.exit();
     }
 
     mainWindow = new BrowserWindow({


### PR DESCRIPTION
Several things break when WinBoat is opened multiple times, one great example is the QMP connection in #60.
This PR disallows such behaviour using electron's [app.requestSingleInstanceLock()](https://www.electronjs.org/docs/latest/api/app\#apprequestsingleinstancelockadditionaldata), focusing the original instance instead.