### PR TITLE
Renamed 'cores' to 'threads'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "winboat",
-    "version": "0.7.2",
+    "version": "0.7.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "winboat",
-            "version": "0.7.2",
+            "version": "0.7.10",
             "dependencies": {
                 "@electron/remote": "^2.1.2",
                 "@iconify/vue": "^4.3.0",

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -26,7 +26,7 @@ const defaultCompose: ComposeConfig = {
             "environment": {
                 "VERSION": "11",
                 "RAM_SIZE": "4G",
-                "CPU_CORES": "4",
+                "CPU_THREADS": "4",
                 "DISK_SIZE": "64G",
                 "USERNAME": "MyWindowsUser",
                 "PASSWORD": "MyWindowsPassword",
@@ -118,7 +118,7 @@ export class InstallManager {
         const composeContent = { ...defaultCompose }
 
         composeContent.services.windows.environment.RAM_SIZE = `${this.conf.ramGB}G`;
-        composeContent.services.windows.environment.CPU_CORES = `${this.conf.cpuThreads}`;
+        composeContent.services.windows.environment.CPU_THREADS = `${this.conf.cpuThreads}`;
         composeContent.services.windows.environment.DISK_SIZE = `${this.conf.diskSpaceGB}G`;
         composeContent.services.windows.environment.VERSION = this.conf.windowsVersion;
         composeContent.services.windows.environment.LANGUAGE = this.conf.windowsLanguage;

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col gap-10 overflow-x-hidden" :class="{ 'hidden': !maxNumCores }">
+    <div class="flex flex-col gap-10 overflow-x-hidden" :class="{ 'hidden': !maxNumThreads }">
         <div>
             <x-label class="mb-4 text-neutral-300">Resources</x-label>
             <div class="flex flex-col gap-4">
@@ -34,23 +34,23 @@
                         <div class="flex flex-row items-center gap-2 mb-2">
                             <Icon class="text-violet-400 inline-flex size-8" icon="solar:cpu-bold"></Icon>
                             <h1 class="text-lg my-0 font-semibold">
-                                CPU Cores
+                                CPU Threads
                             </h1>
                         </div>
                         <p class="text-neutral-400 text-[0.9rem] !pt-0 !mt-0">
-                            How many CPU Cores are allocated to the Windows virtual machine
+                            How many CPU Threads are allocated to the Windows virtual machine
                         </p>
                     </div>
                     <div class="flex flex-row justify-center items-center gap-2">
                         <x-input
                             class="max-w-16 text-right text-[1.1rem]"
                             min="2"
-                            :max="maxNumCores"
-                            :value="numCores"
-                            @input="(e: any) => numCores = Number(/^\d+$/.exec(e.target.value)![0] || 4)"
+                            :max="maxNumThreads"
+                            :value="numThreads"
+                            @input="(e: any) => numThreads = Number(/^\d+$/.exec(e.target.value)![0] || 4)"
                             required
                         ></x-input>
-                        <p class="text-neutral-100">Cores</p>
+                        <p class="text-neutral-100">Threads</p>
                     </div>
                 </x-card>
                 <x-card
@@ -211,9 +211,9 @@ const HOMEFOLDER_SHARE_STR = "${HOME}:/shared";
 
 // For Resources
 const compose = ref<ComposeConfig | null>(null);
-const numCores = ref(0);
-const origNumCores = ref(0);
-const maxNumCores = ref(0);
+const numThreads = ref(0);
+const origNumThreads = ref(0);
+const maxNumThreads = ref(0);
 const ramGB = ref(0);
 const origRamGB = ref(0);
 const maxRamGB = ref(0);
@@ -233,8 +233,8 @@ onMounted(async () => {
 async function assignValues() {
     compose.value = winboat.parseCompose();
 
-    numCores.value = Number(compose.value.services.windows.environment.CPU_CORES);
-    origNumCores.value = numCores.value;
+    numThreads.value = Number(compose.value.services.windows.environment.CPU_THREADS);
+    origNumThreads.value = numThreads.value;
 
     ramGB.value = Number(compose.value.services.windows.environment.RAM_SIZE.split("G")[0]);
     origRamGB.value = ramGB.value;
@@ -244,12 +244,12 @@ async function assignValues() {
 
     const specs = await getSpecs();
     maxRamGB.value = specs.ramGB;
-    maxNumCores.value = specs.cpuThreads;
+    maxNumThreads.value = specs.cpuThreads;
 }
 
 async function applyChanges() {
     compose.value!.services.windows.environment.RAM_SIZE = `${ramGB.value}G`;
-    compose.value!.services.windows.environment.CPU_CORES = `${numCores.value}`;
+    compose.value!.services.windows.environment.CPU_THREADS = `${numThreads.value}`;
 
     const composeHasHomefolderShare = compose.value!.services.windows.volumes.includes(HOMEFOLDER_SHARE_STR);
 
@@ -274,12 +274,12 @@ async function applyChanges() {
 const errors = computed(() => {
     let errCollection: string[] = [];
 
-    if (!numCores.value || numCores.value < 2) {
-        errCollection.push("You must allocate at least two CPU cores for Windows to run properly")
+    if (!numThreads.value || numThreads.value < 2) {
+        errCollection.push("You must allocate at least two CPU threads for Windows to run properly")
     }
 
-    if (numCores.value > maxNumCores.value) {
-        errCollection.push("You cannot allocate more CPU cores to Windows than you have available")
+    if (numThreads.value > maxNumThreads.value) {
+        errCollection.push("You cannot allocate more CPU threads to Windows than you have available")
     }
 
     if (!ramGB.value || ramGB.value < 4) {
@@ -294,7 +294,7 @@ const errors = computed(() => {
 })
 
 const saveButtonDisabled = computed(() => {
-    const hasResourceChanges = origNumCores.value !== numCores.value || origRamGB.value !== ramGB.value || shareHomeFolder.value !== origShareHomeFolder.value;
+    const hasResourceChanges = origNumThreads.value !== numThreads.value || origRamGB.value !== ramGB.value || shareHomeFolder.value !== origShareHomeFolder.value;
     const shouldBeDisabled = errors.value.length || !hasResourceChanges || isApplyingChanges.value;
     return shouldBeDisabled;
 })

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -72,7 +72,7 @@
                         <Icon class="size-8 text-violet-400" icon="solar:cpu-bold"></Icon>
                         <h2 class="my-0 text-2xl">CPU</h2>
                     </div>
-                    <p class="!my-0 text-gray-400 h-6 overflow-hidden">{{ compose?.services.windows.environment.CPU_CORES }} Virtual Cores</p>
+                    <p class="!my-0 text-gray-400 h-6 overflow-hidden">{{ compose?.services.windows.environment.CPU_THREADS }} Virtual Threads </p>
                     <p class="!my-0 text-gray-400 h-6 overflow-hidden">Frequency: {{ (winboat.metrics.value.cpu.frequency / 1000).toFixed(2) }} GHz</p>
                 </div>
             </x-card>

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -294,10 +294,10 @@
     
                         <div class="flex flex-col gap-6">
                             <div>
-                                <label for="select-cpu-cores" class="text-sm text-neutral-400">Select CPU Cores</label>
+                                <label for="select-cpu-threads" class="text-sm text-neutral-400">Select CPU Threads</label>
                                 <div class="flex flex-row gap-4 items-center">
                                     <x-slider
-                                        id="select-cpu-cores"
+                                        id="select-cpu-threads"
                                         @change="(e: any) => cpuThreads = Number(e.target.value)"
                                         class="w-[50%]"
                                         :value="cpuThreads"
@@ -306,7 +306,7 @@
                                         step="1"
                                         ticks
                                     ></x-slider>
-                                    <x-label>{{ cpuThreads }} Cores</x-label>
+                                    <x-label>{{ cpuThreads }} Threads</x-label>
                                 </div>
                             </div>
         
@@ -387,8 +387,8 @@
                                     <span class="text-base text-white">{{ windowsLanguage }}</span>
                                 </div>
                                 <div class="flex flex-col">
-                                    <span class="text-sm text-gray-400">CPU Cores</span>
-                                    <span class="text-base text-white">{{ cpuThreads }} Cores</span>
+                                    <span class="text-sm text-gray-400">CPU Threads</span>
+                                    <span class="text-base text-white">{{ cpuThreads }} Threads</span>
                                 </div>
                                 <div class="flex flex-col">
                                     <span class="text-sm text-gray-400">RAM</span>

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export type ComposeConfig = {
             environment: {
                 VERSION: WindowsVersionKey;
                 RAM_SIZE: string;
-                CPU_CORES: string;
+                CPU_THREADS: string;
                 DISK_SIZE: string;
                 USERNAME: string;
                 PASSWORD: string;

--- a/winboat.md
+++ b/winboat.md
@@ -8,7 +8,7 @@
 - Windows Version
 - Language
 - Keyboard Layout (?)
-- Cores
+- Threads
 - RAM
 - Disk Size
 - Storage Folder


### PR DESCRIPTION
In the installer it lets you select a certain amount of cores, but it actually means the amount of threads. I fixed it :D