### PR TITLE
feat: Add `Logs` field to `Bug Report` form

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -35,6 +35,17 @@ body:
       required: true
   - type: textarea
     attributes:
+      label: Logs
+      description: "Please drag 'n drop your `.log` files from `~/.winboat`, then format them accordingly"
+      placeholder: |
+        - [winboat.log](https://github.com/user-attachments/files/.../winboat.log)
+        - [install.log](https://github.com/user-attachments/files/.../install.log)
+        - [qmp.log](https://github.com/user-attachments/files/.../qmp.log)
+        ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       label: Expected Behavior
       description: Describe what should happen in this case.
     validations:


### PR DESCRIPTION
Added a field so users can submit their logs by drag & dropping them in the issue form.
Right now it is not required, (See: [L#44](https://github.com/Levev/winboat/blob/20c7e4d051ab49d53a83814eeac347f6df778a0c/.github/ISSUE_TEMPLATE/1-bug-report.yml?plain=1#L44)), although changing that is pretty trivial.