### PR TITLE
Fixed an issue where the app list could not be obtained on Japanese Windows 11 Pro.

### DIFF
--- a/guest_server/main.go
+++ b/guest_server/main.go
@@ -44,14 +44,13 @@ type Metrics struct {
 }
 
 func getApps(w http.ResponseWriter, r *http.Request) {
-	// Run the PowerShell script
-	cmd := exec.Command("powershell", "-ExecutionPolicy", "Bypass", "-File", "scripts\\apps.ps1")
+	cmd := exec.Command("powershell", "-ExecutionPolicy", "Bypass", "-Command", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; & '.\\scripts\\apps.ps1'")
 	output, err := cmd.Output()
 	if err != nil {
 		http.Error(w, "Failed to execute script: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write(output)
 }


### PR DESCRIPTION
Hello.

I can't successfully retrieve the app list on a Japanese version of Windows 11 Pro.

When I retrieve the app list from the guest server using the following command, I found that the character encoding is Shift-JIS.

`wget http://localhost:7148/apps`

By changing the character encoding of the apps.ps1 output to UTF-8, I was able to retrieve the app list on a Japanese version of Windows.