### PR TITLE
fix: Remove CPU arguments

### DIFF
--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -21,7 +21,7 @@ export const DefaultCompose: ComposeConfig = {
     },
     "services": {
         "windows": {
-            "image": "ghcr.io/dockur/windows:5.02",
+            "image": "ghcr.io/dockur/windows:5.03",
             "container_name": "WinBoat",
             "environment": {
                 "VERSION": "11",


### PR DESCRIPTION
In the new version (v5.00) of the container, I add this automaticly when an AMD cpu is detected (not an Intel). That removes the need for this ARGUMENT.

P.S. Very cool project!