### PR TITLE
chore: update flake.nix for version 0.8.6-alpha

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
         src = pkgs.fetchurl {
           url = "https://github.com/TibixDev/winboat/releases/download/v${version}/winboat-${version}-x64.tar.gz";
-          sha256 = "0000000000000000000000000000000000000000000000000000";
+          sha256 = "sha256-YX/OMG/jWKXZPcimuhhJ6YCAlZYCAu9lzulGQ/mkgp8=";
         };
         
         nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
         src = pkgs.fetchurl {
           url = "https://github.com/TibixDev/winboat/releases/download/v${version}/winboat-${version}-x64.tar.gz";
-          sha256 = "1mvvd6y0wcpqh6wmjzpax7pkdpwcibhb9y7hnrd7x79fr0s5f3mp";
+          sha256 = "0000000000000000000000000000000000000000000000000000";
         };
         
         nativeBuildInputs = [


### PR DESCRIPTION
Adapted SHA256 value for 0.8.6-alpha