### PR TITLE
Implement wm prefix config and option

### DIFF
--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -11,6 +11,7 @@ export type WinboatConfigObj = {
     passedThroughDevices: PTSerializableDeviceInfo[];
     customApps: WinApp[]
     experimentalFeatures: boolean
+    wmClassPrefix: string
 };
 
 const defaultConfig: WinboatConfigObj = {
@@ -19,7 +20,8 @@ const defaultConfig: WinboatConfigObj = {
     rdpMonitoringEnabled: false,
     passedThroughDevices: [],
     customApps: [],
-    experimentalFeatures: false
+    experimentalFeatures: false,
+    wmClassPrefix: "winboat-",
 };
 
 export class WinboatConfig { 

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -617,7 +617,7 @@ export class Winboat {
         ${this.#wbConfig?.config.smartcardEnabled ? '/smartcard' : ''}\
         /compression\
         /scale:${this.#wbConfig?.config.scale ?? 100}\
-        /wm-class:"${cleanAppName}"\
+        /wm-class:"${this.#wbConfig?.config.wmClassPrefix ?? ''}${cleanAppName}"\
         /app:program:"${app.Path}",name:"${cleanAppName}" &`;
 
         if (app.Path == InternalApps.WINDOWS_DESKTOP) {

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -290,6 +290,29 @@
                     </div>
                 </x-card>
 
+                <!-- Display Scaling -->
+                <x-card
+                    class="flex relative z-10 flex-row justify-between items-center p-2 py-3 my-0 w-full backdrop-blur-xl backdrop-brightness-150 bg-neutral-800/20">
+                    <div>
+                        <div class="flex flex-row gap-2 items-center mb-2">
+                            <Icon class="inline-flex text-violet-400 size-8" icon="uil:scaling-right"></Icon>
+                            <h1 class="my-0 text-lg font-semibold">
+                                WM Class Prefix
+                            </h1>
+                        </div>
+                        <p class="text-neutral-400 text-[0.9rem] !pt-0 !mt-0">
+                            Controls the prefix used for the WM_CLASS property of application windows. This can help with window management and theming in certain desktop environments.
+                        </p>
+                    </div>
+                    <div class="flex flex-row gap-2 justify-center items-center">
+                        <x-input
+                            class="max-w-32 text-right text-[1.1rem]"
+                            :value="wbConfig.config.wmClassPrefix"
+                            @input="(e: any) => wbConfig.config.wmClassPrefix = e.target.value || ''"
+                        ></x-input>
+                    </div>
+                </x-card>
+
                 <!-- Smartcard Passthrough -->
                 <x-card
                     class="flex flex-row justify-between items-center p-2 py-3 my-0 w-full backdrop-blur-xl backdrop-brightness-150 bg-neutral-800/20">


### PR DESCRIPTION
Creates an implementation for setting the /wm-class: xfreerdp option, and a wmClassPrefix config to go alongside it in wbconfig.
Should implement #228 

Sets the default class prefix to `winboat-`