### PR TITLE
Fixed typo in SetupUI

### DIFF
--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -512,7 +512,7 @@
                         <h1 class="text-3xl font-semibold">Installation</h1>
                         <p class="text-lg text-gray-400 text-justify">
                             WinBoat is now installing Windows. Please be patient as this may take up to an hour.
-                            In the meantime you can grab coffee and check the status <a href="http://127.0.0.1:8006" @click="openAnchorLink">in your browser</a>.
+                            In the meantime, you can grab a coffee and check the installation status <a href="http://127.0.0.1:8006" @click="openAnchorLink">in your browser</a>.
                         </p>
     
                         <!-- Installing -->


### PR DESCRIPTION
changed "In the meantime you can grab coffee and check the status" to "In the meantime, you can grab a coffee and check the installation status" (line 515, ./src/renderer/views/SetupUI.vue)