### PR TITLE
FunctionTyposAndConsistency

### DIFF
--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -231,9 +231,9 @@ export class Winboat {
                 logger.info(`Winboat Container state changed to ${_containerStatus}`);
 
                 if (_containerStatus === ContainerStatus.Running) {
-                    await this.createAPIInvervals();
+                    await this.createAPIIntervals();
                 } else {
-                    await this.destroyAPIInvervals();
+                    await this.destroyAPIIntervals();
                 }
             }
         }, 1000);
@@ -250,7 +250,7 @@ export class Winboat {
     /**
      * Creates the intervals which rely on the Winboat Guest API.
      */
-    async createAPIInvervals() {
+    async createAPIIntervals() {
         logger.info("Creating Winboat API intervals...");
         const HEALTH_WAIT_MS = 1000;
         const METRICS_WAIT_MS = 1000;
@@ -339,7 +339,7 @@ export class Winboat {
      * Destroys the intervals which rely on the Winboat Guest API.
      * This is called when the container is in any state other than Running.
      */
-    async destroyAPIInvervals() {
+    async destroyAPIIntervals() {
         logger.info("Destroying Winboat API intervals...");
         if (this.#healthInterval) {
             clearInterval(this.#healthInterval);
@@ -370,9 +370,9 @@ export class Winboat {
                     this.qmpMgr.qmpSocket.destroy();
                 }
                 this.qmpMgr = null;
-                logger.info("[destroyAPIInvervals] QMP Manager destroyed because container is no longer running");
+                logger.info("[destroyAPIIntervals] QMP Manager destroyed because container is no longer running");
             } catch(e) {
-                logger.error("[destroyAPIInvervals] Failed to destroy QMP Manager");
+                logger.error("[destroyAPIIntervals] Failed to destroy QMP Manager");
                 logger.error(e);
             }
         }

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -478,7 +478,7 @@
                         >
                             <x-label><strong>Enable home folder sharing</strong></x-label>
                             <x-label class="text-gray-400">
-                                By checking this box, you aknowledge the risks mentioned above
+                                By checking this box, you acknowledge the risks mentioned above
                             </x-label>
                         </x-checkbox>
 


### PR DESCRIPTION
src/renderer/lib/winboat.ts:
Renamed the createAPIInvervals function to createAPIIntervals
Renamed the destroyAPIInvervals function to destroyAPIIntervals
Updated the related log messages: [destroyAPIInvervals] to [destroyAPIIntervals]

src/renderer/views/SetupUI.vue:
Corrected the "aknowledge" typo to "acknowledge" on line 481.