### PR TITLE
Set default path to ~/winboat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "winboat",
-    "version": "0.8.5",
+    "version": "0.8.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "winboat",
-            "version": "0.8.5",
+            "version": "0.8.7",
             "dependencies": {
                 "@electron/remote": "^2.1.2",
                 "@iconify/vue": "^4.3.0",

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -692,7 +692,7 @@ const $router = useRouter();
 const specs = ref<Specs>({ ...defaultSpecs });
 const currentStepIdx = ref(0);
 const currentStep = computed(() => steps[currentStepIdx.value]);
-const installFolder = ref("");
+const installFolder = ref(path.join(os.homedir(), 'winboat'));
 const windowsVersion = ref<WindowsVersionKey>("11");
 const windowsLanguage = ref("English");
 const customIsoPath = ref("");


### PR DESCRIPTION
Some people don't really care where winboat is installed, so I added a default installation path.