### PR TITLE
Desktop icon support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "winboat",
-    "version": "0.8.5",
+    "version": "0.8.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "winboat",
-            "version": "0.8.5",
+            "version": "0.8.7",
             "dependencies": {
                 "@electron/remote": "^2.1.2",
                 "@iconify/vue": "^4.3.0",

--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -13,6 +13,7 @@ export type WinboatConfigObj = {
     customApps: WinApp[]
     experimentalFeatures: boolean
     multiMonitor: number
+    hasDesktopShortcut: boolean
 };
 
 const defaultConfig: WinboatConfigObj = {
@@ -24,6 +25,7 @@ const defaultConfig: WinboatConfigObj = {
     customApps: [],
     experimentalFeatures: false,
     multiMonitor: 0,
+    hasDesktopShortcut: false,
 };
 
 export class WinboatConfig { 

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -37,7 +37,7 @@ const presetApps: WinApp[] = [
         Icon: AppIcons[InternalApps.WINDOWS_DESKTOP],
         Source: "internal",
         Path: InternalApps.WINDOWS_DESKTOP,
-        Usage: 0 
+        Usage: 0
     },
     {
         Name: "⚙️ Windows Explorer",

--- a/src/renderer/views/Apps.vue
+++ b/src/renderer/views/Apps.vue
@@ -172,10 +172,18 @@
                             <x-label class="truncate text-ellipsis">{{ app.Name }}</x-label>
                         </div>
                         <Icon icon="cuida:caret-right-outline"></Icon>
-                        <WBContextMenu v-if="app.Source === 'custom'">
-                            <WBMenuItem @click="removeCustomApp(app)">
+                        <WBContextMenu>
+                            <WBMenuItem v-if="app.Source === 'custom'" @click="removeCustomApp(app)">
                                 <Icon class="size-4" icon="mdi:trash-can"></Icon>
                                 <x-label>Remove Custom App</x-label>
+                            </WBMenuItem>
+                            <WBMenuItem v-if="!wbConfig.config.hasDesktopShortcut" @click="addDesktopShortcut(app)">
+                                <Icon class="size-4" icon="mdi:plus"></Icon>
+                                <x-label>Add Desktop Shortcut</x-label>
+                            </WBMenuItem>
+                            <WBMenuItem v-if="wbConfig.config.hasDesktopShortcut" @click="removeDesktopShortcut(app)">
+                                <Icon class="size-4" icon="mdi:minus"></Icon>
+                                <x-label>Remove Desktop Shortcut</x-label>
                             </WBMenuItem>
                         </WBContextMenu>
                     </x-card>
@@ -212,11 +220,13 @@ import WBMenuItem from '../components/WBMenuItem.vue';
 import { AppIcons, DEFAULT_ICON } from '../data/appicons';
 import { GUEST_API_PORT } from '../lib/constants';
 import { debounce } from '../utils/debounce';
+import { WinboatConfig } from '../lib/config';
 import { Jimp, JimpMime } from 'jimp';
 const nodeFetch: typeof import('node-fetch').default = require('node-fetch');
 const FormData: typeof import('form-data') = require('form-data');
 
 const winboat = new Winboat();
+const wbConfig = new WinboatConfig();
 const apps = ref<WinApp[]>([]);
 const searchInput = ref('');
 const sortBy = ref('');
@@ -375,6 +385,14 @@ async function addCustomApp() {
 async function removeCustomApp(app: WinApp) {
     await winboat.appMgr!.removeCustomApp(app);
     apps.value = await winboat.appMgr!.getApps(apiURL.value);
+}
+
+function addDesktopShortcut(app: WinApp) {
+    wbConfig.config.hasDesktopShortcut = true;
+}   
+
+function removeDesktopShortcut(app: WinApp) {
+    wbConfig.config.hasDesktopShortcut = false;
 }
 
 /**


### PR DESCRIPTION
I made this draft pull request with the intention of eventually adding desktop icon support

How I currently plan on doing this (might change)

Make winboat support launching apps using a CLI app (winboat launch notepad for example). It defaults to looking in the user's path, otherwise a prompt will show up that asks the user where winboat is installed. I also plan on adding a loading spinner while the app launches, since the VM might take a bit to boot.
