### PR TITLE
Update Windows image to v5.12

### DIFF
--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -25,7 +25,7 @@ export const DefaultCompose: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:5.07",
+            image: "ghcr.io/dockur/windows:5.12",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",


### PR DESCRIPTION
Should be fully backwards compatible with the current (v5.07) image, but fixes a few annoying bugs.