### PR TITLE
Update tailwind.config.ts (purge to content)

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    purge: ["./src/renderer/index.html", "./src/renderer/**/*.{vue,js,ts,jsx,tsx}"],
+    content: ["./src/renderer/index.html", "./src/renderer/**/*.{vue,js,ts,jsx,tsx}"],
     darkMode: false, // or 'media' or 'class'
     theme: {
         extend: {},


### PR DESCRIPTION
Hello maintainers and contributors,

It seems like we are using Tailwind CSS 3.14.17 (specified in package.json) but purge seems to be depreciated and doesn't work in Tailwind anymore? I have thus updated "purge" to "content" to make it work. (Also shows depreciation warnings during building WinBoat from source)  Source: https://github.com/tailwindlabs/tailwindcss/discussions/7568

<img width="711" height="75" alt="image" src="https://github.com/user-attachments/assets/8490f864-84d4-424b-87c5-2aaffa90ddbd" />

Got this too but is a different warning about leaking memory: 

<img width="1303" height="52" alt="image" src="https://github.com/user-attachments/assets/8347fa49-83d3-4206-97b0-faa9688c461c" />


2 quick questions:

1: Why are we not using Tailwind CSS 4.1, it seems to be the latest version?
2: Electron-builder has support for a .snap file. Why is that not in use?

Kind Regards,
adeel26in