### PR TITLE
fix: check winboat disk space instead of its parent path

### DIFF
--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -943,8 +943,22 @@ const installFolderErrors = computedAsync(async () => {
         errors.push("The selected install location is not writable");
     }
 
+    // Create /winboat
+    const winboatPath = path.join(parentPath, "winboat");
+    const isWinboatPathCreated = false;
+    try {
+        fs.mkdirSync(winboatPath, { recursive: true });
+        isWinboatPathCreated = true;
+        console.log("Created winboat directory at", winboatPath);
+    } catch (err) {
+        console.error(err);
+    }
+
     // Check if we have enough disk space
-    const diskSpace = await checkDiskSpace(parentPath);
+    const diskSpace = await checkDiskSpace(isWinboatPathCreated ? winboatPath : parentPath);
+    if (isWinboatPathCreated) {
+        await fs.rm(winboatPath, { recursive: true });
+    }
     const freeGB = Math.floor(diskSpace.free / (1024 * 1024 * 1024));
     if (freeGB < MIN_DISK_GB) {
         errors.push(


### PR DESCRIPTION
Fixes #404

I personally don't like this approach as this breaks general expectations I'd have as a user. I better like (with bias) the approach I suggested [here](https://github.com/TibixDev/winboat/issues/404#issuecomment-3448350775).

Marking this as draft until there's more discussion on the tracking issue.