### PR TITLE
flake: Replace freerdp3 with freerdp in nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         
         nativeBuildInputs = [
           pkgs.makeWrapper
-          pkgs.freerdp3
+          pkgs.freerdp
           pkgs.usbutils
           pkgs.libusb1
         ];


### PR DESCRIPTION
freerdp3 is deprecated in recent nixpkgs:

```
error: 'freerdp3' has been renamed to/replaced by 'freerdp'
```