### PR TITLE
Add tls rdp option to skip Kerberos

### DIFF
--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -76,6 +76,7 @@ const stockArgs = [
     "/microphone:sys:pulse",
     "/floatbar",
     "/compression",
+    "/sec:tls",
 ];
 
 /**


### PR DESCRIPTION
By adding this:
- the process of opening apps is actually faster
- audio, clipboard and fullscreen are still supported
- kerberos is being skipped, avoiding stuff like -- [26769:00006893] [ERROR][com.winpr.sspi.Kerberos] - [kerberos_AcquireCredentialsHandleA]: krb5glue_get_init_creds (Client's credentials have been revoked [-1765328366]) -- which currently delays the process of opening apps cause of rdp falling back to ntlm only after kerberos. It doesnt in fact require kerberos or a domain