### PR TITLE
fix: Add default homebrew bin directory to process.env.PATH

### DIFF
--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -3,6 +3,7 @@ const path: typeof import("path") = require("node:path");
 
 // Should be {home}/.winboat
 export const WINBOAT_DIR = path.join(os.homedir(), ".winboat");
+export const DEFAULT_HOMEBREW_DIR = path.join(os.homedir(), "../linuxbrew/.linuxbrew/bin");
 
 export const WINDOWS_VERSIONS = {
     "11": "Windows 11 Pro",

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -4,7 +4,18 @@ import { router } from "./router";
 import { MotionPlugin } from "@vueuse/motion";
 import "./index.css";
 import { autoScroll } from "./directives/autoscroll";
+import { DEFAULT_HOMEBREW_DIR } from "./lib/constants";
 import VueApexCharts from "vue3-apexcharts";
+
+const process: typeof import("process") = require("node:process");
+
+/**
+ * @note A big chunk of our userbase uses WinBoat under an immutable distro through GearLever.
+ * In case it's the flatpak version of GearLever, PATH, and some other environment variable will get stripped by default.
+ * We include the default homebrew bin directiory for exactly this reason.
+ * It's not WinBoat's responsibility if the PATH envvar is incomplete, but in this case it affects a lot of users.
+ */
+process.env.PATH && (process.env.PATH += `:${DEFAULT_HOMEBREW_DIR}`);
 
 createApp(App)
     .directive("auto-scroll", autoScroll)


### PR DESCRIPTION
A big chunk of our userbase uses WinBoat under an immutable distro through GearLever.
In case it's the flatpak version of GearLever, PATH, and some other environment variable will get stripped by default.
We include the default homebrew bin directiory for exactly this reason.
It's not WinBoat's responsibility if the PATH envvar is incomplete, but in this case it affects a lot of users.