### PR TITLE
Fix the following error: crun: cannot stat `/dev/bus/usb/00x/00x`

### DIFF
--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -39,6 +39,8 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
                 "data:/storage",
                 "${HOME}:/shared",
                 "./oem:/oem",
+                "/dev:/dev:rslave",
+                "/dev/pts:/dev/pts"
             ],
             devices: ["/dev/kvm", "/dev/bus/usb"],
         },


### PR DESCRIPTION
Feel free to change the commit message, as reported few times on discord, I'm using Fedora Atomic (it happens on Silverblue and Kinoite) with podman/podman-compose and this change to the volume fixed the following error:

2025-11-29 00:14:44 | ERROR | Failed to run container action 'podman  container  start  WinBoat'
2025-11-29 00:14:44 | ERROR | Error: Command failed: podman container start WinBoat
Error: unable to start container "64f6f99244bd6e5c15c592184db61b2a0f21a5c9bc1f4b9e1a80f7357daab08d": crun: cannot stat `/dev/bus/usb/001/004`: No such file or directory: OCI runtime attempted to invoke a command that was not found