### PR TITLE
feat: Add custom folder mounts configuration

### DIFF
--- a/src/renderer/components/ConfigCard.vue
+++ b/src/renderer/components/ConfigCard.vue
@@ -58,7 +58,7 @@
             <template v-else-if="props.type === 'switch'">
                 <x-switch
                     :toggled="value"
-                    @toggle="(_: any) => { $emit('toggle'); (value = !value) }"
+                    @toggle="(_: any) => { emit('toggle'); (value = !value) }"
                     size="large"
                 />
             </template>
@@ -124,6 +124,9 @@ type PropsType = {
 };
 
 const props = defineProps<PropsType>();
+const emit = defineEmits<{
+    (e: "toggle"): void;
+}>();
 const value = defineModel("value");
 
 function ensureNumericInput(e: any) {

--- a/src/renderer/components/CustomVolumeMounts.vue
+++ b/src/renderer/components/CustomVolumeMounts.vue
@@ -121,9 +121,12 @@ const newMount = ref<CustomVolumeMount>({
 // Validate existing mounts (host path may have been deleted)
 const mountErrors = computed(() => {
     return props.modelValue.map(mount => {
-        const hostValidation = validateHostPath(mount.hostPath);
-        if (!hostValidation.valid) return hostValidation.error;
-        return null;
+        try {
+            validateHostPath(mount.hostPath);
+            return null;
+        } catch (e) {
+            return (e as Error).message;
+        }
     });
 });
 
@@ -132,13 +135,19 @@ const newMountError = computed(() => {
     if (!newMount.value.hostPath && !newMount.value.shareName) return null;
 
     if (newMount.value.hostPath) {
-        const hostValidation = validateHostPath(newMount.value.hostPath);
-        if (!hostValidation.valid) return `Host: ${hostValidation.error}`;
+        try {
+            validateHostPath(newMount.value.hostPath);
+        } catch (e) {
+            return `Host: ${(e as Error).message}`;
+        }
     }
 
     if (newMount.value.shareName) {
-        const shareValidation = validateShareName(newMount.value.shareName);
-        if (!shareValidation.valid) return `Share: ${shareValidation.error}`;
+        try {
+            validateShareName(newMount.value.shareName);
+        } catch (e) {
+            return `Share: ${(e as Error).message}`;
+        }
 
         // Check for duplicates
         const isDuplicate = props.modelValue.some(

--- a/src/renderer/components/CustomVolumeMounts.vue
+++ b/src/renderer/components/CustomVolumeMounts.vue
@@ -1,0 +1,206 @@
+<template>
+    <x-card class="flex flex-col p-2 py-3 my-0 w-full backdrop-blur-xl backdrop-brightness-150 bg-neutral-800/20">
+        <div class="flex flex-row gap-2 items-center mb-2">
+            <Icon class="inline-flex text-violet-400 size-8" icon="fluent:folder-add-32-filled"></Icon>
+            <h1 class="my-0 text-lg font-semibold">Custom Folder Mounts</h1>
+        </div>
+        <p class="text-neutral-400 text-[0.9rem] !pt-0 !mt-0 mb-4">
+            Mount additional folders from your Linux filesystem into Windows.
+            They appear under <span class="font-mono bg-neutral-700 rounded-md px-1 py-0.5">\\host.lan\Data\&lt;name&gt;</span>
+        </p>
+
+        <!-- Existing Mounts List -->
+        <TransitionGroup name="mounts" tag="div" class="flex flex-col gap-2 mb-4">
+            <x-card
+                v-for="(mount, index) in modelValue"
+                :key="`${mount.hostPath}-${mount.shareName}`"
+                class="flex flex-row justify-between items-center px-3 py-2 m-0 bg-white/5"
+                :class="{ 'opacity-50': !mount.enabled }"
+            >
+                <div class="flex flex-col gap-1 flex-grow min-w-0">
+                    <div class="flex flex-row gap-2 items-center text-sm flex-wrap">
+                        <span class="text-neutral-300 truncate">{{ mount.hostPath }}</span>
+                        <Icon icon="mdi:arrow-right" class="text-neutral-500 size-4 flex-shrink-0" />
+                        <span class="text-violet-300">{{ mount.shareName }}</span>
+                    </div>
+                    <span v-if="mountErrors[index]" class="text-xs text-red-400">
+                        {{ mountErrors[index] }}
+                    </span>
+                </div>
+                <div class="flex flex-row gap-2 items-center flex-shrink-0 ml-2">
+                    <x-switch
+                        :toggled="mount.enabled"
+                        @toggle="() => toggleMount(index)"
+                        size="small"
+                    />
+                    <x-button
+                        class="!bg-gradient-to-tl from-red-500/20 to-transparent hover:from-red-500/30 transition !border-0"
+                        @click="removeMount(index)"
+                    >
+                        <x-icon href="#remove"></x-icon>
+                    </x-button>
+                </div>
+            </x-card>
+        </TransitionGroup>
+
+        <!-- Add New Mount Form -->
+        <div v-if="showAddForm" class="flex flex-col gap-3 p-3 bg-neutral-700/30 rounded-lg mb-4">
+            <div class="flex flex-col gap-1">
+                <label class="text-xs text-neutral-400">Host Path (Linux)</label>
+                <div class="flex flex-row gap-2">
+                    <x-input
+                        type="text"
+                        class="!max-w-full flex-grow"
+                        :value="newMount.hostPath"
+                        @input="(e: any) => newMount.hostPath = e.target.value"
+                        placeholder="/mnt/games"
+                    />
+                    <x-button @click="selectHostPath">Browse</x-button>
+                </div>
+            </div>
+            <div class="flex flex-col gap-1">
+                <label class="text-xs text-neutral-400">Share Name (folder name in Windows)</label>
+                <x-input
+                    type="text"
+                    class="!max-w-full"
+                    :value="newMount.shareName"
+                    @input="(e: any) => newMount.shareName = e.target.value"
+                    placeholder="games"
+                />
+            </div>
+            <div v-if="newMountError" class="text-sm text-red-400">
+                {{ newMountError }}
+            </div>
+            <div class="flex flex-row gap-2">
+                <x-button @click="cancelAdd">Cancel</x-button>
+                <x-button
+                    toggled
+                    @click="addMount"
+                    :disabled="!!newMountError || !newMount.hostPath || !newMount.shareName"
+                >
+                    Add Mount
+                </x-button>
+            </div>
+        </div>
+
+        <!-- Add Button -->
+        <x-button
+            v-if="!showAddForm"
+            class="!bg-gradient-to-tl from-blue-400/20 shadow-md shadow-blue-950/20 to-transparent hover:from-blue-400/30 transition w-fit"
+            @click="showAddForm = true"
+        >
+            <x-icon href="#add"></x-icon>
+            <x-label>Add Folder Mount</x-label>
+        </x-button>
+    </x-card>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { Icon } from "@iconify/vue";
+import type { CustomVolumeMount } from "../../types";
+import { validateHostPath, validateShareName } from "../lib/volumes";
+
+const electron: typeof import("@electron/remote") = require("@electron/remote");
+
+const props = defineProps<{
+    modelValue: CustomVolumeMount[];
+}>();
+
+const emit = defineEmits<{
+    (e: "update:modelValue", value: CustomVolumeMount[]): void;
+}>();
+
+const showAddForm = ref(false);
+const newMount = ref<CustomVolumeMount>({
+    hostPath: "",
+    shareName: "",
+    enabled: true
+});
+
+// Validate existing mounts (host path may have been deleted)
+const mountErrors = computed(() => {
+    return props.modelValue.map(mount => {
+        const hostValidation = validateHostPath(mount.hostPath);
+        if (!hostValidation.valid) return hostValidation.error;
+        return null;
+    });
+});
+
+// Validate new mount form
+const newMountError = computed(() => {
+    if (!newMount.value.hostPath && !newMount.value.shareName) return null;
+
+    if (newMount.value.hostPath) {
+        const hostValidation = validateHostPath(newMount.value.hostPath);
+        if (!hostValidation.valid) return `Host: ${hostValidation.error}`;
+    }
+
+    if (newMount.value.shareName) {
+        const shareValidation = validateShareName(newMount.value.shareName);
+        if (!shareValidation.valid) return `Share: ${shareValidation.error}`;
+
+        // Check for duplicates
+        const isDuplicate = props.modelValue.some(
+            m => m.shareName === newMount.value.shareName
+        );
+        if (isDuplicate) return "Share name already in use";
+    }
+
+    return null;
+});
+
+function selectHostPath() {
+    electron.dialog.showOpenDialog({
+        title: "Select Folder to Mount",
+        properties: ["openDirectory"]
+    }).then(result => {
+        if (!result.canceled && result.filePaths.length > 0) {
+            newMount.value.hostPath = result.filePaths[0];
+            // Auto-suggest share name from folder name
+            if (!newMount.value.shareName) {
+                const folderName = result.filePaths[0].split("/").pop() || "";
+                newMount.value.shareName = folderName.toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_-]/g, "");
+            }
+        }
+    });
+}
+
+function addMount() {
+    if (newMountError.value) return;
+
+    emit("update:modelValue", [...props.modelValue, { ...newMount.value }]);
+    cancelAdd();
+}
+
+function cancelAdd() {
+    newMount.value = { hostPath: "", shareName: "", enabled: true };
+    showAddForm.value = false;
+}
+
+function removeMount(index: number) {
+    emit("update:modelValue", props.modelValue.filter((_, i) => i !== index));
+}
+
+function toggleMount(index: number) {
+    const updated = [...props.modelValue];
+    updated[index] = { ...updated[index], enabled: !updated[index].enabled };
+    emit("update:modelValue", updated);
+}
+</script>
+
+<style scoped>
+.mounts-move,
+.mounts-enter-active,
+.mounts-leave-active {
+    transition: all 0.3s ease;
+}
+.mounts-enter-from,
+.mounts-leave-to {
+    opacity: 0;
+    transform: translateX(20px);
+}
+.mounts-leave-active {
+    position: absolute;
+}
+</style>

--- a/src/renderer/components/CustomVolumeMounts.vue
+++ b/src/renderer/components/CustomVolumeMounts.vue
@@ -6,7 +6,7 @@
         </div>
         <p class="text-neutral-400 text-[0.9rem] !pt-0 !mt-0 mb-4">
             Mount additional folders from your Linux filesystem into Windows.
-            They appear under <span class="font-mono bg-neutral-700 rounded-md px-1 py-0.5">\\host.lan\Data\&lt;name&gt;</span>
+            They appear under <span class="font-mono bg-neutral-700 rounded-md px-1 py-0.5">\\host.lan\Data2\&lt;name&gt;</span>
         </p>
 
         <!-- Existing Mounts List -->

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -6,6 +6,7 @@ import { Winboat } from "./winboat";
 import { ContainerManager } from "./containers/container";
 import { WinboatConfig } from "./config";
 import { CommonPorts, createContainer, getActiveHostPort } from "./containers/common";
+import { isRootSharedFolderMount } from "./volumes";
 
 const fs: typeof import("fs") = require("fs");
 const path: typeof import("path") = require("path");
@@ -106,7 +107,7 @@ export class InstallManager {
         }
 
         // Shared folder mapping
-        const sharedFolderIdx = composeContent.services.windows.volumes.findIndex(vol => vol.includes("/shared"));
+        const sharedFolderIdx = composeContent.services.windows.volumes.findIndex(isRootSharedFolderMount);
         
         if (!this.conf.sharedFolderPath) {
             // Remove shared folder if not enabled

--- a/src/renderer/lib/volumes.ts
+++ b/src/renderer/lib/volumes.ts
@@ -1,0 +1,126 @@
+const fs: typeof import("fs") = require("node:fs");
+const path: typeof import("path") = require("node:path");
+
+import type { CustomVolumeMount, ComposeConfig } from "../../types";
+
+/**
+ * Validates a host path exists and is accessible
+ */
+export function validateHostPath(hostPath: string): { valid: boolean; error?: string } {
+    try {
+        if (!hostPath) {
+            return { valid: false, error: "Path is required" };
+        }
+        if (!path.isAbsolute(hostPath)) {
+            return { valid: false, error: "Path must be absolute" };
+        }
+        if (!fs.existsSync(hostPath)) {
+            return { valid: false, error: "Path does not exist" };
+        }
+        const stats = fs.statSync(hostPath);
+        if (!stats.isDirectory()) {
+            return { valid: false, error: "Path is not a directory" };
+        }
+        fs.accessSync(hostPath, fs.constants.R_OK);
+        return { valid: true };
+    } catch {
+        return { valid: false, error: "Path is not accessible" };
+    }
+}
+
+/**
+ * Validates a share name (folder name visible in Windows)
+ */
+export function validateShareName(name: string): { valid: boolean; error?: string } {
+    if (!name) {
+        return { valid: false, error: "Name is required" };
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        return { valid: false, error: "Only letters, numbers, underscores, hyphens" };
+    }
+    if (name.length > 32) {
+        return { valid: false, error: "Max 32 characters" };
+    }
+    return { valid: true };
+}
+
+// Base path for custom mounts (avoids /tmp/smb which gets cleaned on container start)
+export const CUSTOM_MOUNT_BASE = "/mnt/winboat";
+
+/**
+ * Converts a CustomVolumeMount to compose volume string format
+ * Mounts under /mnt/winboat/ - symlinks are created in /tmp/smb/ after container starts
+ */
+export function mountToVolumeString(mount: CustomVolumeMount): string {
+    return `${mount.hostPath}:${CUSTOM_MOUNT_BASE}/${mount.shareName}`;
+}
+
+/**
+ * Identifies if a volume string is a custom user mount (not system)
+ * Custom mounts are under /mnt/winboat/ (or legacy paths /tmp/smb/, or bare paths like /gamez)
+ */
+export function isCustomMount(volumeStr: string): boolean {
+    const parts = volumeStr.split(":");
+    const containerPath = parts.length >= 2 ? parts[parts.length - 1] : "";
+
+    // System paths that should NOT be considered custom mounts
+    const systemPaths = ["/storage", "/shared", "/oem", "/dev/bus/usb", "/dev"];
+
+    // If it's a system path, it's not custom
+    if (systemPaths.some(p => containerPath === p || containerPath.startsWith(p + "/"))) {
+        return false;
+    }
+
+    // Current format: /mnt/winboat/<name>
+    if (containerPath.startsWith(CUSTOM_MOUNT_BASE + "/")) {
+        return true;
+    }
+
+    // Legacy format: /tmp/smb/<name>
+    if (containerPath.startsWith("/tmp/smb/")) {
+        return true;
+    }
+
+    // Very old format: bare path like /gamez (not a system path, likely custom)
+    // Only match single-level paths that aren't system
+    if (containerPath.match(/^\/[a-zA-Z0-9_-]+$/)) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Apply custom mounts to a compose config
+ * Removes existing custom mounts and adds enabled ones
+ */
+export function applyCustomMounts(
+    compose: ComposeConfig,
+    mounts: CustomVolumeMount[]
+): void {
+    // Remove existing custom mounts (keep system volumes)
+    compose.services.windows.volumes = compose.services.windows.volumes.filter(
+        vol => !isCustomMount(vol)
+    );
+
+    // Add enabled custom mounts
+    const enabledMounts = mounts
+        .filter(m => m.enabled)
+        .map(mountToVolumeString);
+
+    compose.services.windows.volumes.push(...enabledMounts);
+}
+
+/**
+ * Creates symlinks in /tmp/smb/ pointing to /mnt/winboat/ mounts
+ * This makes custom mounts accessible via \\host.lan\Data\<shareName>
+ * Returns shell commands to execute inside the container
+ */
+export function getSymlinkCommands(mounts: CustomVolumeMount[]): string[] {
+    const enabledMounts = mounts.filter(m => m.enabled);
+    if (enabledMounts.length === 0) return [];
+
+    return enabledMounts.map(mount =>
+        `ln -sfn ${CUSTOM_MOUNT_BASE}/${mount.shareName} /tmp/smb/${mount.shareName}`
+    );
+}

--- a/src/renderer/lib/volumes.ts
+++ b/src/renderer/lib/volumes.ts
@@ -1,7 +1,16 @@
 const fs: typeof import("fs") = require("node:fs");
+const os: typeof import("os") = require("node:os");
 const path: typeof import("path") = require("node:path");
 
 import type { CustomVolumeMount, ComposeConfig } from "../../types";
+
+const SHARED_FOLDER_ROOT = "/shared";
+const CUSTOM_SHARE_ROOT = "/shared2";
+const STORAGE_SHARED_FOLDER_ROOT = "/storage/shared";
+const LEGACY_CUSTOM_DATA_ROOT = "/data2";
+const LEGACY_CUSTOM_MOUNT_BASE = "/mnt/winboat";
+const LEGACY_SAMBA_MOUNT_BASE = "/tmp/smb";
+const LEGACY_SINGLE_PATH_MOUNT = /^\/[a-zA-Z0-9_-]+$/;
 
 /**
  * Validates a host path exists and is accessible.
@@ -32,50 +41,89 @@ export function validateShareName(name: string): void {
     if (name.length > 32) throw new Error(`Name '${name}' exceeds maximum length of 32 characters`);
 }
 
-// Base path for custom mounts (avoids /tmp/smb which gets cleaned on container start)
-export const CUSTOM_MOUNT_BASE = "/mnt/winboat";
+function resolveComposeHostPath(hostPath: string): string {
+    return hostPath.replace("${HOME}", os.homedir());
+}
 
-/**
- * Converts a CustomVolumeMount to compose volume string format
- * Mounts under /mnt/winboat/ - symlinks are created in /tmp/smb/ after container starts
- */
-export function mountToVolumeString(mount: CustomVolumeMount): string {
-    return `${mount.hostPath}:${CUSTOM_MOUNT_BASE}/${mount.shareName}`;
+function getVolumePaths(volumeStr: string): [hostPath: string, containerPath: string] | null {
+    const parts = volumeStr.split(":");
+    if (parts.length < 2) {
+        return null;
+    }
+
+    const lastPart = parts.at(-1)!;
+    const containerPathIndex = lastPart.startsWith("/") ? parts.length - 1 : parts.length - 2;
+    const containerPath = parts[containerPathIndex];
+    if (!containerPath?.startsWith("/")) {
+        return null;
+    }
+
+    return [parts.slice(0, containerPathIndex).join(":"), containerPath];
+}
+
+export function isRootSharedFolderMount(volumeStr: string): boolean {
+    return getVolumePaths(volumeStr)?.[1] === SHARED_FOLDER_ROOT;
+}
+
+function getSharedFolderVolume(compose: ComposeConfig): string | undefined {
+    return compose.services.windows.volumes.find(isRootSharedFolderMount);
+}
+
+export function getSharedFolderHostPath(compose: ComposeConfig): string | null {
+    const sharedFolderVolume = getSharedFolderVolume(compose);
+    const hostPath = sharedFolderVolume ? getVolumePaths(sharedFolderVolume)?.[0] : null;
+    return hostPath ? resolveComposeHostPath(hostPath) : null;
 }
 
 /**
- * Identifies if a volume string is a custom user mount (not system)
- * Custom mounts are under /mnt/winboat/ (or legacy paths /tmp/smb/, or bare paths like /gamez)
+ * Converts a CustomVolumeMount to compose volume string format.
+ * Custom mounts always live under Dockur's Data2 share root.
+ */
+function mountToVolumeString(mount: CustomVolumeMount): string {
+    return `${mount.hostPath}:${CUSTOM_SHARE_ROOT}/${mount.shareName}`;
+}
+
+function isManagedCustomMountPath(containerPath: string): boolean {
+    return (
+        containerPath.startsWith(`${CUSTOM_SHARE_ROOT}/`) ||
+        containerPath.startsWith(`${SHARED_FOLDER_ROOT}/`) ||
+        containerPath.startsWith(`${STORAGE_SHARED_FOLDER_ROOT}/`) ||
+        containerPath.startsWith(`${LEGACY_CUSTOM_DATA_ROOT}/`) ||
+        containerPath.startsWith(`${LEGACY_CUSTOM_MOUNT_BASE}/`) ||
+        containerPath.startsWith(`${LEGACY_SAMBA_MOUNT_BASE}/`) ||
+        LEGACY_SINGLE_PATH_MOUNT.test(containerPath)
+    );
+}
+
+/**
+ * Identifies if a volume string is a custom user mount (not system).
+ * Custom mounts live under Data2, with cleanup for older mount layouts.
  */
 export function isCustomMount(volumeStr: string): boolean {
-    const parts = volumeStr.split(":");
-    const containerPath = parts.length >= 2 ? parts[parts.length - 1] : "";
-
-    // System paths that should NOT be considered custom mounts
-    const systemPaths = ["/storage", "/shared", "/oem", "/dev/bus/usb", "/dev"];
-
-    // If it's a system path, it's not custom
-    if (systemPaths.some(p => containerPath === p || containerPath.startsWith(p + "/"))) {
+    const containerPath = getVolumePaths(volumeStr)?.[1];
+    if (!containerPath) {
         return false;
     }
 
-    // Current format: /mnt/winboat/<name>
-    if (containerPath.startsWith(CUSTOM_MOUNT_BASE + "/")) {
-        return true;
+    const systemPaths = [
+        "/storage",
+        SHARED_FOLDER_ROOT,
+        CUSTOM_SHARE_ROOT,
+        STORAGE_SHARED_FOLDER_ROOT,
+        LEGACY_CUSTOM_DATA_ROOT,
+        "/oem",
+        "/dev",
+        "/dev/bus/usb",
+    ];
+    if (systemPaths.includes(containerPath)) {
+        return false;
     }
 
-    // Legacy format: /tmp/smb/<name>
-    if (containerPath.startsWith("/tmp/smb/")) {
-        return true;
+    if (containerPath.startsWith("/dev/")) {
+        return false;
     }
 
-    // Very old format: bare path like /gamez (not a system path, likely custom)
-    // Only match single-level paths that aren't system
-    if (containerPath.match(/^\/[a-zA-Z0-9_-]+$/)) {
-        return true;
-    }
-
-    return false;
+    return isManagedCustomMountPath(containerPath);
 }
 
 /**
@@ -97,18 +145,4 @@ export function applyCustomMounts(
         .map(mountToVolumeString);
 
     compose.services.windows.volumes.push(...enabledMounts);
-}
-
-/**
- * Creates symlinks in /tmp/smb/ pointing to /mnt/winboat/ mounts
- * This makes custom mounts accessible via \\host.lan\Data\<shareName>
- * Returns shell commands to execute inside the container
- */
-export function getSymlinkCommands(mounts: CustomVolumeMount[]): string[] {
-    const enabledMounts = mounts.filter(m => m.enabled);
-    if (enabledMounts.length === 0) return [];
-
-    return enabledMounts.map(mount =>
-        `ln -sfn ${CUSTOM_MOUNT_BASE}/${mount.shareName} /tmp/smb/${mount.shareName}`
-    );
 }

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -462,7 +462,7 @@ export class Winboat {
 
         for (const cmd of commands) {
             try {
-                await execAsync(`docker exec WinBoat ${cmd}`);
+                await execAsync(`${this.containerMgr!.executableAlias} exec WinBoat ${cmd}`);
                 logger.info(`Created symlink: ${cmd}`);
             } catch (e) {
                 logger.error(`Failed to create symlink: ${cmd}`);

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -21,6 +21,7 @@ import { setIntervalImmediately } from "../utils/interval";
 import { ExecFileAsyncError } from "./exec-helper";
 import { ContainerManager, ContainerStatus } from "./containers/container";
 import { CommonPorts, ContainerRuntimes, createContainer, getActiveHostPort } from "./containers/common";
+import { getSymlinkCommands } from "./volumes";
 
 const nodeFetch: typeof import("node-fetch").default = require("node-fetch");
 const fs: typeof import("fs") = require("node:fs");
@@ -307,6 +308,8 @@ export class Winboat {
                 logger.info(`Winboat Guest API went ${this.isOnline ? "online" : "offline"}`);
 
                 if (this.isOnline.value) {
+                    // Create symlinks for custom volume mounts
+                    await this.createCustomMountSymlinks();
                     await this.checkVersionAndUpdateGuestServer();
                 }
             }
@@ -440,6 +443,32 @@ export class Winboat {
             username: compose.services.windows.environment.USERNAME,
             password: compose.services.windows.environment.PASSWORD,
         };
+    }
+
+    /**
+     * Creates symlinks in /tmp/smb/ for custom volume mounts
+     * This allows Windows to access them via \\host.lan\Data\<shareName>
+     */
+    async createCustomMountSymlinks() {
+        const mounts = this.#wbConfig?.config.customVolumeMounts || [];
+        const commands = getSymlinkCommands(mounts);
+
+        if (commands.length === 0) {
+            logger.info("No custom volume mounts to symlink");
+            return;
+        }
+
+        logger.info(`Creating symlinks for ${commands.length} custom volume mount(s)`);
+
+        for (const cmd of commands) {
+            try {
+                await execAsync(`docker exec WinBoat ${cmd}`);
+                logger.info(`Created symlink: ${cmd}`);
+            } catch (e) {
+                logger.error(`Failed to create symlink: ${cmd}`);
+                logger.error(e);
+            }
+        }
     }
 
     async #connectQMPManager() {

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -21,7 +21,6 @@ import { setIntervalImmediately } from "../utils/interval";
 import { ExecFileAsyncError } from "./exec-helper";
 import { ContainerManager, ContainerStatus } from "./containers/container";
 import { CommonPorts, ContainerRuntimes, createContainer, getActiveHostPort } from "./containers/common";
-import { getSymlinkCommands } from "./volumes";
 
 const nodeFetch: typeof import("node-fetch").default = require("node-fetch");
 const fs: typeof import("fs") = require("node:fs");
@@ -308,8 +307,6 @@ export class Winboat {
                 logger.info(`Winboat Guest API went ${this.isOnline ? "online" : "offline"}`);
 
                 if (this.isOnline.value) {
-                    // Create symlinks for custom volume mounts
-                    await this.createCustomMountSymlinks();
                     await this.checkVersionAndUpdateGuestServer();
                 }
             }
@@ -443,32 +440,6 @@ export class Winboat {
             username: compose.services.windows.environment.USERNAME,
             password: compose.services.windows.environment.PASSWORD,
         };
-    }
-
-    /**
-     * Creates symlinks in /tmp/smb/ for custom volume mounts
-     * This allows Windows to access them via \\host.lan\Data\<shareName>
-     */
-    async createCustomMountSymlinks() {
-        const mounts = this.#wbConfig?.config.customVolumeMounts || [];
-        const commands = getSymlinkCommands(mounts);
-
-        if (commands.length === 0) {
-            logger.info("No custom volume mounts to symlink");
-            return;
-        }
-
-        logger.info(`Creating symlinks for ${commands.length} custom volume mount(s)`);
-
-        for (const cmd of commands) {
-            try {
-                await execAsync(`${this.containerMgr!.executableAlias} exec WinBoat ${cmd}`);
-                logger.info(`Created symlink: ${cmd}`);
-            } catch (e) {
-                logger.error(`Failed to create symlink: ${cmd}`);
-                logger.error(e);
-            }
-        }
     }
 
     async #connectQMPManager() {

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -479,7 +479,11 @@ import {
 import { ComposePortEntry, ComposePortMapper, Range } from "../utils/port";
 import CustomVolumeMounts from "../components/CustomVolumeMounts.vue";
 import type { CustomVolumeMount } from "../../types";
-import { applyCustomMounts } from "../lib/volumes";
+import {
+    applyCustomMounts,
+    getSharedFolderHostPath,
+    isRootSharedFolderMount,
+} from "../lib/volumes";
 const { app }: typeof import("@electron/remote") = require("@electron/remote");
 const electron: typeof import("electron") = require("electron").remote || require("@electron/remote");
 const os: typeof import("os") = require("node:os");
@@ -543,13 +547,10 @@ async function assignValues() {
     ramGB.value = Number(compose.value.services.windows.environment.RAM_SIZE.split("G")[0]);
     origRamGB.value = ramGB.value;
 
-    // Find any volume that ends with /shared
-    const sharedVolume = compose.value.services.windows.volumes.find(v => v.includes("/shared"));
-    if (sharedVolume) {
+    const sharedFolderHostPath = getSharedFolderHostPath(compose.value);
+    if (sharedFolderHostPath) {
         shareFolder.value = true;
-        // Extract the path before :/shared
-        const [hostPath] = sharedVolume.split(":");
-        sharedFolderPath.value = hostPath.replace("${HOME}", os.homedir());
+        sharedFolderPath.value = sharedFolderHostPath;
     } else {
         shareFolder.value = false;
         sharedFolderPath.value = "";
@@ -581,13 +582,9 @@ async function saveCompose() {
     compose.value!.services.windows.environment.RAM_SIZE = `${ramGB.value}G`;
     compose.value!.services.windows.environment.CPU_CORES = `${numCores.value}`;
 
-    // Remove any existing shared volume
-    const existingSharedVolume = compose.value!.services.windows.volumes.find(v => v.includes("/shared"));
-    if (existingSharedVolume) {
-        compose.value!.services.windows.volumes = compose.value!.services.windows.volumes.filter(
-            v => !v.includes("/shared"),
-        );
-    }
+    compose.value!.services.windows.volumes = compose.value!.services.windows.volumes.filter(
+        volume => !isRootSharedFolderMount(volume),
+    );
 
     // Add the new shared volume if enabled
     if (shareFolder.value && sharedFolderPath.value) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,3 +122,9 @@ export type USBDevice = {
     productID: string;
     alias: string;
 };
+
+export type CustomVolumeMount = {
+    hostPath: string;
+    shareName: string;
+    enabled: boolean;
+};


### PR DESCRIPTION
  ## Summary

  Add the ability for users to mount custom folders from the Linux host
  filesystem into the Windows VM. Mounted folders appear in Windows at
  `\\host.lan\Data\<name>`.

  **Features:**
  - Add/remove custom folder mounts via the Configuration panel
  - Browse for folders using native file picker
  - Enable/disable individual mounts without removing them
  - Path validation (checks directory exists and is accessible)
  - Share name validation (alphanumeric, underscores, hyphens only)

  ## Changes

  - `CustomVolumeMounts.vue` - New component for managing mounts
  - `volumes.ts` - Validation helpers and compose config utilities
  - `types.ts` - New `CustomVolumeMount` type
  - `Config.vue` - Integration into settings page
  - `config.ts` / `winboat.ts` - Backend integration

  ## Test Plan

  - [x] Add a new mount via folder browser
  - [x] Add a mount by typing path manually
  - [x] Verify validation errors appear for invalid paths
  - [x] Toggle mount on/off
  - [x] Remove a mount
  - [x] Restart WinBoat and verify mounts persist
  - [x] Access mounted folder from Windows at `\\host.lan\Data\<name>`

  Closes #343
  Closes #44