### PR TITLE
Allow `dev` versions of Docker Compose

### DIFF
--- a/src/renderer/lib/containers/docker.ts
+++ b/src/renderer/lib/containers/docker.ts
@@ -171,10 +171,14 @@ export class DockerContainer extends ContainerManager {
             if (dockerComposeOutput) {
                 // Example output: "Docker Compose version v2.35.1"
                 // Example output 2: "Docker Compose version 2.36.2"
+                // Example output 3: "Docker Compose version dev"
                 const versionMatch = /(\d+\.\d+\.\d+)/.exec(dockerComposeOutput);
                 if (versionMatch) {
                     const majorVersion = Number.parseInt(versionMatch[1].split(".")[0], 10);
                     specs.dockerComposeInstalled = majorVersion >= 2;
+                } else if (dockerComposeOutput.includes("dev")) {
+                    // Development builds are assumed to be v2+
+                    specs.dockerComposeInstalled = true;
                 } else {
                     specs.dockerComposeInstalled = false; // No valid version found
                 }


### PR DESCRIPTION
This fixes #573. It also would be good practice to support any developers who are genuinely using a bleeding edge version of Docker Compose.
