### PR TITLE
Copying a file leaves the original perms intact

### DIFF
--- a/guest_server/util.go
+++ b/guest_server/util.go
@@ -16,10 +16,13 @@ func checkErr(err error) {
 
 // Copy a file from src to dst
 func copyFile(src string, dst string) {
+	info, err := os.Stat(src)
+	checkErr(err)
+
 	// Read all content of src to data, may cause OOM for a large file.
 	data, err := os.ReadFile(src)
 	checkErr(err)
 	// Write data to dst
-	err = os.WriteFile(dst, data, 0644)
+	err = os.WriteFile(dst, data, info.Mode())
 	checkErr(err)
 }


### PR DESCRIPTION
Changed the copyFile function in the guest_server, so now it wouldn't let the user surpass the original app perms and mode by copying it. Leaves the original perms intact.