### PR TITLE
feat: Allow customizing region settings and keyboard layout

### DIFF
--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -19,6 +19,8 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
                 PASSWORD: "MyWindowsPassword",
                 HOME: "${HOME}",
                 LANGUAGE: "English",
+                REGION: "en-US",
+                KEYBOARD: "en-US",
                 USER_PORTS: "7148",
                 HOST_PORTS: "7149",
                 ARGUMENTS: "-qmp tcp:0.0.0.0:7149,server,wait=off",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -19,6 +19,8 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
                 PASSWORD: "MyWindowsPassword",
                 HOME: "${HOME}",
                 LANGUAGE: "English",
+                REGION: "en-US",
+                KEYBOARD: "en-US",
                 NETWORK: "user",
                 USER_PORTS: "7148",
                 HOST_PORTS: "7149",

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -87,6 +87,8 @@ export class InstallManager {
         composeContent.services.windows.environment.DISK_SIZE = `${this.conf.diskSpaceGB}G`;
         composeContent.services.windows.environment.VERSION = this.conf.windowsVersion;
         composeContent.services.windows.environment.LANGUAGE = this.conf.windowsLanguage;
+        composeContent.services.windows.environment.REGION = this.conf.windowsRegion;
+        composeContent.services.windows.environment.KEYBOARD = this.conf.keyboardLayout;
         composeContent.services.windows.environment.USERNAME = this.conf.username;
         composeContent.services.windows.environment.PASSWORD = this.conf.password;
 

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -368,6 +368,38 @@
                                 </x-menu>
                             </x-select>
                         </div>
+                        <div>
+                            <label for="select-windows-region" class="text-sm mb-4 text-neutral-400">Select Region</label>
+                            <x-input
+                                id="select-windows-region"
+                                class="w-64 max-w-64"
+                                type="text"
+                                minlength="2"
+                                maxlength="16"
+                                size="large"
+                                :value="windowsRegion"
+                                @input="(e: any) => (windowsRegion = e.target.value)"
+                            >
+                                <x-icon href="#earth"></x-icon>
+                                <x-label>Name</x-label>
+                            </x-input>
+                        </div>
+                        <div>
+                            <label for="select-keyboard-layout" class="text-sm mb-4 text-neutral-400">Select Keyboard Layout</label>
+                            <x-input
+                                id="select-keyboard-layout"
+                                class="w-64 max-w-64"
+                                type="text"
+                                minlength="2"
+                                maxlength="16"
+                                size="large"
+                                :value="keyboardLayout"
+                                @input="(e: any) => (keyboardLayout = e.target.value)"
+                            >
+                                <x-icon href="#comment"></x-icon>
+                                <x-label>Name</x-label>
+                            </x-input>
+                        </div>
                         <div class="mt-4">
                             <div class="flex flex-col gap-2">
                                 <label for="select-iso" class="text-xs text-neutral-400">Custom ISO (Optional)</label>
@@ -894,6 +926,8 @@ const currentStep = computed(() => steps[currentStepIdx.value]);
 const installFolder = ref(path.join(os.homedir(), "winboat"));
 const windowsVersion = ref<WindowsVersionKey>("11");
 const windowsLanguage = ref("English");
+const windowsRegion = ref("en-US");
+const keyboardLayout = ref("en-US");
 const customIsoPath = ref("");
 const customIsoFileName = ref("");
 const cpuCores = ref(2);
@@ -1073,6 +1107,8 @@ function install() {
     const installConfig: InstallConfiguration = {
         windowsVersion: windowsVersion.value,
         windowsLanguage: windowsLanguage.value,
+        windowsRegion: windowsRegion.value,
+        keyboardLayout: keyboardLayout.value,
         cpuCores: cpuCores.value,
         ramGB: ramGB.value,
         installFolder: installFolder.value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type Specs = {
 export type InstallConfiguration = {
     windowsVersion: WindowsVersionKey;
     windowsLanguage: string;
+    windowsRegion: string;
+    keyboardLayout: string;
     cpuCores: number;
     ramGB: number;
     installFolder: string;
@@ -72,6 +74,8 @@ export type ComposeConfig = {
                 PASSWORD: string;
                 HOME: string;
                 LANGUAGE: string;
+                REGION: string;
+                KEYBOARD: string;
                 ARGUMENTS: string;
                 HOST_PORTS: string;
                 [key: string]: string; // Allow additional env vars


### PR DESCRIPTION
At time of writing, winboat does not expose `dockur/windows`' support for customizing the keyboard layout and region & formatting settings.

Adding my keyboard layout each time I reset/delete the winboat VM is a little cumbersome.

Thus, changes made in this allow users to customize the "Region & Formatting" setting and the keyboard layout during the setup of winboat.

### Questions concerning the PR
I think it might make sense to use `""` or `undefined` as the default for both `REGION` and `KEYBOARD` instead of `"en-US"`. I assume this will make `dockur/windows` fall back to the Windows ISO's default keyboard layout/region. However, I wanted to make sure the end user knows how to format the keyboard layout and region name.

What are your thoughts on that? Is there a somewhat sweeter solution?

Thank you so much for maintaining this project! I seriously love the ease of setting up winboat!