### PR TITLE
fix: Fix Podman link to the correct link

### DIFF
--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -125,7 +125,7 @@
                                 </div>
                                 installed
                                 <a
-                                    :href="containerRuntime === 'Podman'
+                                    :href="containerRuntime === ContainerRuntimes.PODMAN
                                         ? 'https://podman.io/getting-started/installation'
                                         : 'https://docs.docker.com/engine/install/'"
                                     @click="openAnchorLink"

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -125,12 +125,13 @@
                                 </div>
                                 installed
                                 <a
-                                    href="https://docs.docker.com/engine/install/"
+                                    :href="containerRuntime === 'Podman'
+                                        ? 'https://podman.io/getting-started/installation'
+                                        : 'https://docs.docker.com/engine/install/'"
                                     @click="openAnchorLink"
                                     target="_blank"
                                     class="text-violet-400 hover:underline ml-1"
-                                    >How?</a
-                                >
+                                >How?</a>
                             </li>
 
                             <!-- Docker Specific Requirements -->


### PR DESCRIPTION
Fixed the link for the Podman "How?" leading to Docker instead of Podman

Closes #523 
Closes #760 