### PR TITLE
Readme improve for podman installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-
-      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` could be too old. Make sure you have **Version 4.x.x** or higher to ensure the installation completes successfully.
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` could be too old. Make sure you have **Version 4.x.x** or higher to ensure the installation completes successfully.
+      - On Debian/Ubuntu and forks, the Podman version installed with `apt install` could be too old. Make sure you have **Version 4.x.x** or higher to ensure the installation completes successfully.
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-        > [!NOTE]  
         > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-> [!NOTE]  
-> On Debian/Ubuntu and fork, the podman version install with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+        > [!NOTE]  
+        > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
+> [!NOTE]  
+> On Debian/Ubuntu and fork, the podman version install with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-> [!NOTE]  
-> On Debian/Ubuntu and fork, the podman version install with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+      > [!NOTE]  
+      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-        > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+
+      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-        > [!NOTE]  
-        > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+> [!NOTE]  
+> On Debian/Ubuntu and fork, the podman version install with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Before running WinBoat, ensure your system meets the following requirements:
 - **In case of Podman:**
   - **Podman**: Required for containerization
       - [Installation Guide](https://podman.io/docs/installation#installing-on-linux)
-      > [!NOTE]  
-      > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
+        > [!NOTE]  
+        > On Debian/Ubuntu and forks, the Podman version installed with `apt install` can be too old. Make sure you have **Version 4.x.x** or higher to have the installation complete successfully
   - **Podman Compose**: Required for compatibility with podman-compose.yml files
       - [Installation Guide](https://github.com/containers/podman-compose?tab=readme-ov-file#installation)
 - **FreeRDP**: Required for remote desktop connection (Please make sure you have **Version 3.x.x** with sound support included)


### PR DESCRIPTION
When I try for the first time to create a podman with WinBoat, the podman creation failed with an error like this (I have deleted the log files, so it is not hyper precise sorry) :  `"podman compose -f" command failed, flag "f" doesn't exist"`. After a lot of debugging, I simply realised that my podman version was too old (because the one installed with apt install on Pop_OS! is old), and this was causing the error.
So I propose this change in the README to avoid other users like me loose time for something that is simple.

I'm not quite sure of the format; it's not very similar to what we have at the moment, but feel free to let me know where to make changes or do the change by yourself so that it fits better.