### PR TITLE
fix novnc issue

### DIFF
--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -26,7 +26,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
             },
             cap_add: ["NET_ADMIN"],
             ports: [
-                "127.0.0.1::8006", // VNC Web Interface
+                "127.0.0.1:8006:8006", // VNC Web Interface
                 "127.0.0.1::7148", // Winboat Guest Server API
                 "127.0.0.1::7149", // QEMU QMP Port
                 "127.0.0.1::3389/tcp", // RDP


### PR DESCRIPTION
Hello,

I saw issue #557 and was investigating the problem. I deployed WinBoat using Podman and noticed that it assigns a random port on the host side. However, we need port 8006 to be exposed on the host as well.

Best regards,
NextWorks