### PR TITLE
feat(renderer): understand current config structure

### DIFF
--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -103,6 +103,15 @@ export class WinboatConfig {
     // Due to us wrapping WinboatConfig in reactive, this can't be private
     configData: WinboatConfigObj = { ...defaultConfig };
 
+    async browseSharedFolder(): Promise<string | null> {
+        const { dialog } = await import("electron");
+        const result = await dialog.showOpenDialog({
+            title: "Select Shared Folder",
+            properties: ["openDirectory"]
+        });
+        return result.canceled ? null : result.filePaths[0];
+    }
+
     static getInstance() {
         WinboatConfig.instance ??= new WinboatConfig();
         return WinboatConfig.instance;


### PR DESCRIPTION
🚀 New Feature

This file contains the WinboatConfig class which stores all configuration including sharedFolderPath. I need to see the current implementation to understand how to add a browse function for the shared folder.

Changes:
- `src/renderer/lib/config.ts` (modified)

Closes #178