### PR TITLE
Fix: quote strings in podman compose

### DIFF
--- a/src/renderer/lib/containers/podman.ts
+++ b/src/renderer/lib/containers/podman.ts
@@ -58,7 +58,11 @@ export class PodmanContainer extends ContainerManager {
     }
 
     writeCompose(compose: ComposeConfig): void {
-        const composeContent = YAML.stringify(compose, { nullStr: "" });
+        const composeContent = YAML.stringify(compose, {
+            nullStr: "",
+            defaultStringType: "QUOTE_DOUBLE",
+            defaultKeyType: "PLAIN",
+        });
         fs.writeFileSync(this.composeFilePath, composeContent, { encoding: "utf-8" });
 
         containerLogger.info(`Wrote to compose file at: ${this.composeFilePath}`);


### PR DESCRIPTION
Some users have reported that the restart-always/never flag in podman compose yml doesn't work unless they have quotes in the compose. I believe this is a compatibility issue with the podman-compose binary.
This will also protect from special characters in username, password and file path fields.

By flagging defaultStringType as quote double, all default types in the stringify will be quoted.
defaultKeyType as plain then overrides the quotes for the keys in the yml, leaving them unquoted as before.