### PR TITLE
Fix stale prerequisite validation when switching from Docker to Podman

### DIFF
--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -810,6 +810,7 @@
 
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
+import { computedAsync } from "@vueuse/core";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { InstallConfiguration, Specs } from "../../types";

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -812,7 +812,6 @@
 import { Icon } from "@iconify/vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
-import { computedAsync } from "@vueuse/core";
 import { InstallConfiguration, Specs } from "../../types";
 import { getSpecs, getMemoryInfo, defaultSpecs, satisfiesPrequisites, type MemoryInfo } from "../lib/specs";
 import { WINDOWS_VERSIONS, WINDOWS_LANGUAGES, type WindowsVersionKey } from "../lib/constants";
@@ -821,6 +820,7 @@ import { openAnchorLink } from "../utils/openLink";
 import license from "../assets/LICENSE.txt?raw";
 import {
     ContainerRuntimes,
+    type ContainerSpecs,
     DockerSpecs,
     PodmanSpecs,
     getContainerSpecs,
@@ -936,6 +936,7 @@ const sharedFolderPath = ref("");
 const installState = ref<InstallStates>(InstallStates.IDLE);
 const preinstallMsg = ref("");
 const containerRuntime = ref(ContainerRuntimes.DOCKER);
+let containerSpecsRequestId = 0;
 const vncPort = ref(8006);
 // These are the install steps where the container is actually up and running
 const linkableInstallSteps = [ InstallStates.MONITORING_PREINSTALL, InstallStates.INSTALLING_WINDOWS, InstallStates.COMPLETED ];
@@ -972,9 +973,23 @@ watch(folderSharing, (newValue) => {
     }
 });
 
-const containerSpecs = computedAsync(async () => {
-    return await getContainerSpecs(containerRuntime.value);
-});
+const containerSpecs = ref<ContainerSpecs>();
+
+watch(
+    containerRuntime,
+    async runtime => {
+        const requestId = ++containerSpecsRequestId;
+
+        // Clear the previous runtime checks immediately so the UI cannot reuse stale pass states.
+        containerSpecs.value = undefined;
+        const nextContainerSpecs = await getContainerSpecs(runtime);
+
+        if (requestId !== containerSpecsRequestId) return;
+
+        containerSpecs.value = nextContainerSpecs;
+    },
+    { immediate: true },
+);
 
 function containerInstalled(containerSpecs: DockerSpecs | PodmanSpecs | undefined) {
     if (!containerSpecs) return false;

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -107,10 +107,7 @@
                                 <span v-else class="text-red-500">✘</span>
 
                                 <div>
-                                    <x-select
-                                        @change="(e: any) => (containerRuntime = e.detail.newValue)"
-                                        class="w-fit"
-                                    >
+                                    <x-select @change="handleContainerRuntimeChange" class="w-fit">
                                         <x-menu>
                                             <x-menuitem
                                                 v-for="(runtime, key) in Object.values(ContainerRuntimes)"
@@ -246,7 +243,7 @@
                                 toggled
                                 class="px-6"
                                 @click="currentStepIdx++"
-                                :disabled="!satisfiesPrequisites(specs, containerSpecs)"
+                                :disabled="checkingPrerequisites || !satisfiesPrequisites(specs, containerSpecs)"
                             >
                                 Next
                             </x-button>
@@ -810,9 +807,9 @@
 
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
-import { computedAsync } from "@vueuse/core";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
+import { computedAsync } from "@vueuse/core";
 import { InstallConfiguration, Specs } from "../../types";
 import { getSpecs, getMemoryInfo, defaultSpecs, satisfiesPrequisites, type MemoryInfo } from "../lib/specs";
 import { WINDOWS_VERSIONS, WINDOWS_LANGUAGES, type WindowsVersionKey } from "../lib/constants";
@@ -937,7 +934,7 @@ const sharedFolderPath = ref("");
 const installState = ref<InstallStates>(InstallStates.IDLE);
 const preinstallMsg = ref("");
 const containerRuntime = ref(ContainerRuntimes.DOCKER);
-let containerSpecsRequestId = 0;
+const checkingPrerequisites = ref(true);
 const vncPort = ref(8006);
 // These are the install steps where the container is actually up and running
 const linkableInstallSteps = [ InstallStates.MONITORING_PREINSTALL, InstallStates.INSTALLING_WINDOWS, InstallStates.COMPLETED ];
@@ -979,18 +976,22 @@ const containerSpecs = ref<ContainerSpecs>();
 watch(
     containerRuntime,
     async runtime => {
-        const requestId = ++containerSpecsRequestId;
-
-        // Clear the previous runtime checks immediately so the UI cannot reuse stale pass states.
+        checkingPrerequisites.value = true;
         containerSpecs.value = undefined;
-        const nextContainerSpecs = await getContainerSpecs(runtime);
-
-        if (requestId !== containerSpecsRequestId) return;
-
-        containerSpecs.value = nextContainerSpecs;
+        try {
+            containerSpecs.value = await getContainerSpecs(runtime);
+        } finally {
+            checkingPrerequisites.value = false;
+        }
     },
     { immediate: true },
 );
+
+function handleContainerRuntimeChange(e: CustomEvent<{ newValue: ContainerRuntimes }>) {
+    checkingPrerequisites.value = true;
+    containerSpecs.value = undefined;
+    containerRuntime.value = e.detail.newValue;
+}
 
 function containerInstalled(containerSpecs: DockerSpecs | PodmanSpecs | undefined) {
     if (!containerSpecs) return false;

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -114,6 +114,9 @@
                                                 :key="key"
                                                 :value="runtime"
                                                 :toggled="runtime === containerRuntime"
+                                                @pointerdown="beginContainerRuntimeChange(runtime)"
+                                                @keydown.enter="beginContainerRuntimeChange(runtime)"
+                                                @click="beginContainerRuntimeChange(runtime)"
                                             >
                                                 <x-label>{{ runtime }}</x-label>
                                             </x-menuitem>
@@ -242,7 +245,7 @@
                             <x-button
                                 toggled
                                 class="px-6"
-                                @click="currentStepIdx++"
+                                @click="goToInstallLocationStep"
                                 :disabled="checkingPrerequisites || !satisfiesPrequisites(specs, containerSpecs)"
                             >
                                 Next
@@ -988,9 +991,21 @@ watch(
 );
 
 function handleContainerRuntimeChange(e: CustomEvent<{ newValue: ContainerRuntimes }>) {
+    beginContainerRuntimeChange(e.detail.newValue);
+}
+
+function beginContainerRuntimeChange(runtime: ContainerRuntimes) {
+    if (runtime === containerRuntime.value) return;
+
     checkingPrerequisites.value = true;
     containerSpecs.value = undefined;
-    containerRuntime.value = e.detail.newValue;
+    containerRuntime.value = runtime;
+}
+
+function goToInstallLocationStep() {
+    if (checkingPrerequisites.value || !satisfiesPrequisites(specs.value, containerSpecs.value)) return;
+
+    currentStepIdx.value++;
 }
 
 function containerInstalled(containerSpecs: DockerSpecs | PodmanSpecs | undefined) {


### PR DESCRIPTION
## Summary

This fixes a setup wizard bug where the `Next` button could remain enabled after switching the container runtime from Docker to Podman, even though Podman prerequisites had not been validated yet.

## What changed

- replaced the async computed `containerSpecs` state with an explicit `watch` on `containerRuntime`
- clear the previous runtime's prerequisite state immediately when the runtime changes
- added a request id guard so outdated async checks cannot overwrite the latest runtime state

## Why

The previous implementation could briefly reuse the old runtime's successful prerequisite result while the new runtime check was still in flight. That allowed users to continue with stale validation state.

## Testing

- switched between Docker and Podman in the setup prerequisites step
- confirmed the `Next` button is disabled immediately after switching runtimes
- confirmed the button only becomes enabled again after the current runtime's prerequisites pass

## Related

- Closes #756