### PR TITLE
Update Windows Docker image version to v5.15

### DIFF
--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -8,7 +8,7 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:5.14",
+            image: "ghcr.io/dockur/windows:5.15",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -8,7 +8,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:5.14",
+            image: "ghcr.io/dockur/windows:5.15",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",


### PR DESCRIPTION
Update the Docker image to v5.15. There are no changes that can affect WinBoat, so it should be fully backwards compatible.