### PR TITLE
fix: resolve Vue Ref unwrapping bugs for Guest Server online status

### DIFF
--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -304,7 +304,7 @@ export class Winboat {
             const _isOnline = await this.getHealth();
             if (_isOnline !== this.isOnline.value) {
                 this.isOnline.value = _isOnline;
-                logger.info(`Winboat Guest API went ${this.isOnline ? "online" : "offline"}`);
+                logger.info(`Winboat Guest API went ${this.isOnline.value ? "online" : "offline"}`);
 
                 if (this.isOnline.value) {
                     await this.checkVersionAndUpdateGuestServer();
@@ -617,7 +617,7 @@ export class Winboat {
     }
 
     async launchApp(app: WinApp) {
-        if (!this.isOnline) throw new Error("Cannot launch app, Winboat is offline");
+        if (!this.isOnline.value) throw new Error("Cannot launch app, Winboat is offline");
 
         if (customAppCallbacks[app.Path]) {
             logger.info(`Found custom app command for '${app.Name}'`);


### PR DESCRIPTION
This PR fixes Vue Ref unwrapping bugs that incorrectly logged and handled offline states in the frontend.

#### Changes

1. **Fix Vue Ref unwrapping bugs ([winboat.ts](file:///home/v/Projects/winboat-git/src/renderer/lib/winboat.ts))**
   - **Issue 1:** The logger checked `this.isOnline` (which is a Vue `Ref` wrapper object) in a ternary expression: `this.isOnline ? "online" : "offline"`. Because the `Ref` wrapper object is always truthy, this always evaluated to `"online"`, which flooded log files with `"went online"` messages even during offline transitions.
   - **Issue 2:** The app launch guard checked `!this.isOnline`, which also incorrectly evaluated to `false`, causing app launches to proceed when the VM was offline and fail silently downstream rather than displaying a clear error.
   - **Fix:** Appended `.value` to both unwrapped `Ref` boolean checks (`this.isOnline.value`).