### PR TITLE
chore: Fix GUI not rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "chalk": "^5.6.2",
         "chokidar": "^5.0.0",
         "electron": "^40.2.1",
-        "electron-builder": "^26.15.2",
+        "electron-builder": "^26.7.0",
         "postcss": "^8.5.6",
         "prettier": "3.8.1",
         "tailwindcss": "^3.4.17",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -30,7 +30,7 @@
             "filter": ["**/*"]
         },
         {
-            "from": "src/renderer",
+            "from": "build/renderer",
             "to": "renderer",
             "filter": ["**/*"]
         },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "chalk": "^5.6.2",
         "chokidar": "^5.0.0",
         "electron": "^40.2.1",
-        "electron-builder": "^26.15.2",
+        "electron-builder": "^26.7.0",
         "postcss": "^8.5.6",
         "prettier": "3.8.1",
         "tailwindcss": "^3.4.17",


### PR DESCRIPTION
Downgraded electron builder to v16.7.0, changed renderer path back to `build/`