### PR TITLE
fix: cache check never working, port index 0 bug, config write per key

### DIFF
--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -175,8 +175,8 @@ export class WinboatConfig {
             console.log("Successfully read the config file");
 
             // Some fields might be missing after an update, so we merge them with the default config
+            let hasMissing = false;
             for (const key in defaultConfig) {
-                let hasMissing = false;
                 if (!(key in configObj)) {
                     // @ts-expect-error This is valid
                     configObj[key] = defaultConfig[key];
@@ -187,13 +187,13 @@ export class WinboatConfig {
                         }`,
                     );
                 }
+            }
 
-                // If we have any missing keys, we should just write the config back to disk so those new keys are saved
-                // We cannot use this.writeConfig() here since #configData is not populated yet
-                if (hasMissing) {
-                    fs.writeFileSync(WinboatConfig.configPath, JSON.stringify(configObj, null, 4), "utf-8");
-                    console.log("Wrote updated config with missing keys to disk");
-                }
+            // If we have any missing keys, we should just write the config back to disk so those new keys are saved
+            // We cannot use this.writeConfig() here since #configData is not populated yet
+            if (hasMissing) {
+                fs.writeFileSync(WinboatConfig.configPath, JSON.stringify(configObj, null, 4), "utf-8");
+                console.log("Wrote updated config with missing keys to disk");
             }
 
             return { ...configObj };

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -127,7 +127,7 @@ class AppManager {
         const newApps = (await res.json()) as WinApp[];
         newApps.push(...presetApps, ...this.#wbConfig!.config.customApps);
 
-        if (this.appCache.values.length == newApps.length && !options.forceRead) return;
+        if (this.appCache.length == newApps.length && !options.forceRead) return;
 
         for (const appIdx in newApps) {
             newApps[appIdx].Usage = this.appCache.find(app => app.Name == newApps[appIdx].Name)?.Usage || 0;

--- a/src/renderer/utils/port.ts
+++ b/src/renderer/utils/port.ts
@@ -288,7 +288,7 @@ export class ComposePortMapper {
             guestPort = Number.parseInt(guestPort);
         }
 
-        return !!this.findGuestPortIndex(guestPort, protocol);
+        return this.findGuestPortIndex(guestPort, protocol) !== undefined;
     }
 
     /**


### PR DESCRIPTION
Three bugs I found:

- \`appCache.values.length\` was always \`undefined\` because \`Array.values()\` returns an iterator which doesn't have a \`.length\` property. The early-return cache check never fired, meaning every \`updateAppCache\` call re-processed the full app list unnecessarily. Changed to \`appCache.length\`.

- \`hasShortPortMapping\` returned \`false\` for a port at index 0 because \`!!0\` is \`false\`. If the first port entry matched, it was invisible. Changed to \`!== undefined\`.

- The config repair loop was writing the config file to disk inside the loop for each missing key, instead of once after all keys are patched. Moved the write outside.