### PR TITLE
Fix: Recreate container from compose file if removed or running into errors

### DIFF
--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -8,6 +8,8 @@ export const WINBOAT_DIR = process.env.XDG_DATA_HOME ?
     path.join(os.homedir(), ".local", "share", "winboat-app");
 export const DEFAULT_HOMEBREW_DIR = path.join(os.homedir(), "../linuxbrew/.linuxbrew/bin");
 
+export const CONTAINER_LOG_FILE = path.join(WINBOAT_DIR, "container.log");
+
 export const WINDOWS_VERSIONS = {
     "11": "Windows 11 Pro",
     "11l": "Windows 11 LTSC 2024",

--- a/src/renderer/lib/containers/container.ts
+++ b/src/renderer/lib/containers/container.ts
@@ -1,10 +1,10 @@
 import { ComposeConfig } from "../../../types";
-import { WINBOAT_DIR } from "../constants";
+import { CONTAINER_LOG_FILE } from "../constants";
 import { createLogger } from "../../utils/log";
 
 const path: typeof import("node:path") = require("node:path");
 
-export const containerLogger = createLogger(path.join(WINBOAT_DIR, "container.log"));
+export const containerLogger = createLogger(CONTAINER_LOG_FILE);
 
 export type ComposeDirection = "up" | "down";
 export type ComposeArguments = "--no-start";

--- a/src/renderer/lib/containers/container.ts
+++ b/src/renderer/lib/containers/container.ts
@@ -36,6 +36,7 @@ export enum ContainerStatus {
     PAUSED = "Paused",
     EXITED = "Exited",
     UNKNOWN = "Unknown",
+    ERROR = "ERROR",
 }
 
 // Errors which usually indicate that the container is in a stale/broken state,

--- a/src/renderer/lib/containers/container.ts
+++ b/src/renderer/lib/containers/container.ts
@@ -37,3 +37,35 @@ export enum ContainerStatus {
     EXITED = "Exited",
     UNKNOWN = "Unknown",
 }
+
+// Errors which usually indicate that the container is in a stale/broken state,
+// e.g. because it references a passed-through USB device that is no longer
+// present on the host. In these cases the container can't be started again and
+// needs to be recreated from the compose file
+const STALE_CONTAINER_ERROR_PATTERNS = [
+    /cannot stat `[^`]*`:?\s*no such file or directory/i,
+    /oci runtime attempted to invoke a command that was not found/i,
+    /no such device or address/i,
+];
+
+function getErrorText(error: unknown): string {
+    if (!error) return "";
+    if (typeof error === "string") return error;
+
+    if (typeof error === "object") {
+        const anyError = error as { message?: string; stderr?: string; stdout?: string };
+        return [anyError.message, anyError.stderr, anyError.stdout].filter(Boolean).join("\n");
+    }
+
+    return String(error);
+}
+
+/**
+ * Determines whether an error thrown while starting/interacting with a container
+ * indicates that the container itself is stale/malfunctioning (e.g. due to
+ * an USB passthrough device that no longer exists on the host).
+ */
+export function isStaleContainerError(error: unknown): boolean {
+    const text = getErrorText(error);
+    return STALE_CONTAINER_ERROR_PATTERNS.some(pattern => pattern.test(text));
+}

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -23,7 +23,7 @@ export enum InstallStates {
     INSTALLING_WINDOWS = "Installing Windows",
     COMPLETED = "Completed",
     INSTALL_ERROR = "Install Error",
-};
+}
 
 interface InstallEvents {
     stateChanged: (state: InstallStates) => void;
@@ -96,7 +96,7 @@ export class InstallManager {
 
         // Storage folder mapping
         const storageFolderIdx = composeContent.services.windows.volumes.findIndex(vol => vol.includes("/storage"));
-        
+
         if (storageFolderIdx === -1) {
             logger.warn("No /storage volume found in compose template, adding one...");
             composeContent.services.windows.volumes.push(`${this.conf.installFolder}:/storage`);
@@ -106,7 +106,7 @@ export class InstallManager {
 
         // Shared folder mapping
         const sharedFolderIdx = composeContent.services.windows.volumes.findIndex(vol => vol.includes("/shared"));
-        
+
         if (!this.conf.sharedFolderPath) {
             // Remove shared folder if not enabled
             if (sharedFolderIdx !== -1) {
@@ -116,7 +116,7 @@ export class InstallManager {
         } else {
             // Add or update shared folder
             const volumeStr = `${this.conf.sharedFolderPath}:/shared`;
-            
+
             if (sharedFolderIdx === -1) {
                 composeContent.services.windows.volumes.push(volumeStr);
                 logger.info(`Added shared folder: ${this.conf.sharedFolderPath}`);
@@ -318,6 +318,47 @@ export class InstallManager {
     }
 }
 
+/**
+ * Finds the host storage folder configured in the compose file (i.e. the folder
+ * mapped to `/storage`, which holds the Windows disk image(s)).
+ * @returns `null` if the compose file couldn't be read, no `/storage` volume was
+ * found, or the volume points to a legacy Docker named volume rather than a host path.
+ */
+function findStorageFolderPath(containerRuntime: ContainerManager): string | null {
+    if (!fs.existsSync(containerRuntime.composeFilePath)) return null;
+
+    try {
+        const compose = Winboat.readCompose(containerRuntime.composeFilePath);
+        const storage = compose.services.windows.volumes.find(vol => vol.includes("/storage"));
+        const storageFolder = storage?.split(":").at(0) ?? null;
+
+        // Legacy Docker named volume (e.g. "data:/storage") isn't a host path we can inspect directly
+        if (!storageFolder || !path.isAbsolute(storageFolder)) return null;
+
+        return storageFolder;
+    } catch (e) {
+        logger.error("Failed to read compose file while looking for the storage folder");
+        logger.error(e);
+        return null;
+    }
+}
+
+/**
+ * Checks whether a Windows disk image (e.g. `data.img`, `data2.img`, `data.qcow2`)
+ * exists inside the given storage folder.
+ */
+function hasWindowsDiskImage(storageFolder: string): boolean {
+    if (!fs.existsSync(storageFolder)) return false;
+
+    try {
+        return fs.readdirSync(storageFolder).some(entry => /^data\d*\.(img|qcow2)$/i.test(entry));
+    } catch (e) {
+        logger.error(`Failed to read storage folder at '${storageFolder}'`);
+        logger.error(e);
+        return false;
+    }
+}
+
 export async function isInstalled(): Promise<boolean> {
     // Check if a winboat container exists
     const config = WinboatConfig.readConfigObject(false);
@@ -326,5 +367,29 @@ export async function isInstalled(): Promise<boolean> {
 
     const containerRuntime = createContainer(config.containerRuntime);
 
-    return await containerRuntime.exists();
+    if (await containerRuntime.exists()) {
+        return true;
+    }
+
+    // The container might be missing even though WinBoat was previously installed
+    // e.g. the user might have manually removed the container
+    // If the compose file still exists we can probably recreate it
+    if (!fs.existsSync(containerRuntime.composeFilePath)) {
+        return false;
+    }
+
+    // Check the installation for existing files
+    const storageFolder = findStorageFolderPath(containerRuntime);
+    if (storageFolder && !hasWindowsDiskImage(storageFolder)) {
+        logger.warn(
+            `Found a WinBoat compose file, but no Windows disk image was found in the storage folder at '${storageFolder}'. Not attempting to recreate the container.`,
+        );
+        return false;
+    }
+
+    logger.info(
+        "WinBoat container is missing but installation artifacts (compose file and disk image) were found on disk, attempting to recreate the container...",
+    );
+
+    return true;
 }

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -240,7 +240,6 @@ export class Winboat {
     isUpdatingGuestServer: Ref<boolean> = ref(false);
     containerStatus: Ref<ContainerStatus> = ref(ContainerStatus.EXITED);
     containerActionLoading: Ref<boolean> = ref(false);
-    lastContainerError: Ref<string | null> = ref(null);
     rdpConnected: Ref<boolean> = ref(false);
     metrics: Ref<Metrics> = ref<Metrics>({
         cpu: {
@@ -277,13 +276,17 @@ export class Winboat {
             const _containerStatus = await this.containerMgr!.getStatus();
 
             if (_containerStatus !== this.containerStatus.value) {
-                this.containerStatus.value = _containerStatus;
-                logger.info(`Winboat Container state changed to ${_containerStatus}`);
+                // ERROR is explicitly set, so don't overwrite it from periodic polling.
+                // Keep it until the next user action.
+                if (this.containerStatus.value !== ContainerStatus.ERROR) {
+                    this.containerStatus.value = _containerStatus;
+                    logger.info(`Winboat Container state changed to ${_containerStatus}`);
 
-                if (_containerStatus === ContainerStatus.RUNNING) {
-                    await this.createAPIIntervals();
-                } else {
-                    await this.destroyAPIIntervals();
+                    if (_containerStatus === ContainerStatus.RUNNING) {
+                        await this.createAPIIntervals();
+                    } else {
+                        await this.destroyAPIIntervals();
+                    }
                 }
             }
         }, 1000);
@@ -503,7 +506,6 @@ export class Winboat {
     async startContainer() {
         logger.info("Starting WinBoat container...");
         this.containerActionLoading.value = true;
-        this.lastContainerError.value = null;
 
         try {
             // Start the container if it exists and recreate it if starting it runs into an error
@@ -543,8 +545,7 @@ export class Winboat {
         } catch (e) {
             logger.error("There was an error performing the container action.");
             logger.error(e);
-            this.lastContainerError.value =
-                "Failed to start the WinBoat container. Check the container logs for more details.";
+            this.containerStatus.value = ContainerStatus.ERROR;
             throw e;
         } finally {
             this.containerActionLoading.value = false;
@@ -565,7 +566,6 @@ export class Winboat {
     async restartContainer() {
         logger.info("Restarting WinBoat container...");
         this.containerActionLoading.value = true;
-        this.lastContainerError.value = null;
         try {
             try {
                 await this.containerMgr!.container("restart");
@@ -583,8 +583,7 @@ export class Winboat {
         } catch (e) {
             logger.error("There was an error restarting the container.");
             logger.error(e);
-            this.lastContainerError.value =
-                "Failed to restart the WinBoat container. Check the container logs for more details.";
+            this.containerStatus.value = ContainerStatus.ERROR;
             throw e;
         } finally {
             this.containerActionLoading.value = false;

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -18,7 +18,7 @@ import { openLink } from "../utils/openLink";
 import { MultiMonitorMode, WinboatConfig } from "./config";
 import { HOST_QMP_PORT, HOST_RDP_PORT, NOVNC_URL, WINBOAT_API_URL, WINBOAT_DIR } from "./constants";
 import { ContainerRuntimes, createContainer } from "./containers/common";
-import { ContainerManager, ContainerStatus } from "./containers/container";
+import { ContainerManager, ContainerStatus, isStaleContainerError } from "./containers/container";
 import { ExecFileAsyncError } from "./exec-helper";
 import { QMPManager } from "./qmp";
 
@@ -240,6 +240,7 @@ export class Winboat {
     isUpdatingGuestServer: Ref<boolean> = ref(false);
     containerStatus: Ref<ContainerStatus> = ref(ContainerStatus.EXITED);
     containerActionLoading: Ref<boolean> = ref(false);
+    lastContainerError: Ref<string | null> = ref(null);
     rdpConnected: Ref<boolean> = ref(false);
     metrics: Ref<Metrics> = ref<Metrics>({
         cpu: {
@@ -485,60 +486,135 @@ export class Winboat {
         }, QMP_WAIT_MS);
     }
 
+    /**
+     * Recreates the WinBoat container from its existing compose file.
+     * This is used to recover from a stale/malfunctioning container, e.g. one
+     * that references a passed-through USB device that no longer exists on
+     * the host, which prevents it from being started normally.
+     * @note Mirrors the manual workaround of `container rm` + `compose up`.
+     */
+    async recreateContainer() {
+        logger.warn("[recreateContainer] Recreating WinBoat container from its compose file...");
+        await this.containerMgr!.remove();
+        await this.containerMgr!.compose("up");
+        logger.info("[recreateContainer] Successfully recreated WinBoat container");
+    }
+
     async startContainer() {
         logger.info("Starting WinBoat container...");
         this.containerActionLoading.value = true;
+        this.lastContainerError.value = null;
+
         try {
-            await this.containerMgr!.container("start");
+            // Start the container if it exists and recreate it if starting it runs into an error
+            // If there is no container, create it from the compose file
+            if (await this.containerMgr!.exists()) {
+                try {
+                    await this.containerMgr!.container("start");
+                } catch (e) {
+                    if (isStaleContainerError(e)) {
+                        logger.warn(
+                            "[startContainer] Container appears to be stale/malfunctioning (e.g. a stale USB passthrough reference). Attempting to recreate it...",
+                        );
+                        await this.recreateContainer();
+                    } else {
+                        throw e;
+                    }
+                }
+                logger.info("Successfully started WinBoat container");
+            } else {
+                try {
+                    await this.containerMgr!.compose("up");
+                    const recreated = await this.containerMgr!.exists();
+
+                    if (recreated) {
+                        logger.info("Successfully recreated the WinBoat container from the existing compose file");
+                    } else {
+                        logger.error(
+                            "Failed to recreate the WinBoat container: it still doesn't exist after 'compose up'",
+                        );
+                    }
+                } catch (e) {
+                    logger.error("Failed to recreate the WinBoat container from the existing compose file");
+                    logger.error(e);
+                    throw e;
+                }
+            }
         } catch (e) {
             logger.error("There was an error performing the container action.");
             logger.error(e);
+            this.lastContainerError.value =
+                "Failed to start the WinBoat container. Check the container logs for more details.";
             throw e;
+        } finally {
+            this.containerActionLoading.value = false;
         }
-        logger.info("Successfully started WinBoat container");
-        this.containerActionLoading.value = false;
     }
 
     async stopContainer() {
         logger.info("Stopping WinBoat container...");
         this.containerActionLoading.value = true;
-        await this.containerMgr!.container("stop");
-        logger.info("Successfully stopped WinBoat container");
-        this.containerActionLoading.value = false;
+        try {
+            await this.containerMgr!.container("stop");
+            logger.info("Successfully stopped WinBoat container");
+        } finally {
+            this.containerActionLoading.value = false;
+        }
     }
 
     async restartContainer() {
         logger.info("Restarting WinBoat container...");
         this.containerActionLoading.value = true;
+        this.lastContainerError.value = null;
         try {
-            await this.containerMgr!.container("restart");
+            try {
+                await this.containerMgr!.container("restart");
+            } catch (e) {
+                if (isStaleContainerError(e)) {
+                    logger.warn(
+                        "[restartContainer] Container appears to be stale/malfunctioning (e.g. a stale USB passthrough reference). Attempting to recreate it...",
+                    );
+                    await this.recreateContainer();
+                } else {
+                    throw e;
+                }
+            }
+            logger.info("Successfully restarted WinBoat container");
         } catch (e) {
             logger.error("There was an error restarting the container.");
             logger.error(e);
+            this.lastContainerError.value =
+                "Failed to restart the WinBoat container. Check the container logs for more details.";
             throw e;
+        } finally {
+            this.containerActionLoading.value = false;
         }
-        logger.info("Successfully restarted WinBoat container");
-        this.containerActionLoading.value = false;
     }
 
     async pauseContainer() {
         logger.info("Pausing WinBoat container...");
         this.containerActionLoading.value = true;
-        await this.containerMgr!.container("pause");
-        logger.info("Successfully paused WinBoat container");
-        this.containerActionLoading.value = false;
+        try {
+            await this.containerMgr!.container("pause");
+            logger.info("Successfully paused WinBoat container");
+        } finally {
+            this.containerActionLoading.value = false;
+        }
     }
 
     async unpauseContainer() {
         logger.info("Unpausing WinBoat container...");
         this.containerActionLoading.value = true;
-        await this.containerMgr!.container("unpause");
-        logger.info("Successfully unpaused WinBoat container");
-        this.containerActionLoading.value = false;
+        try {
+            await this.containerMgr!.container("unpause");
+            logger.info("Successfully unpaused WinBoat container");
+        } finally {
+            this.containerActionLoading.value = false;
+        }
     }
 
     // TODO: refactor / possibly remove this
-    /** 
+    /**
         Replaces the compose file, and and updates the container.
         @note Use {@link ContainerManager.writeCompose} in case only disk write is needed
     */

--- a/src/renderer/utils/openLink.ts
+++ b/src/renderer/utils/openLink.ts
@@ -1,6 +1,5 @@
 const { shell }: typeof import("@electron/remote") = require("@electron/remote");
-const path: typeof import("path") = require("node:path");
-import { WINBOAT_DIR } from "../lib/constants";
+import { CONTAINER_LOG_FILE } from "../lib/constants";
 
 export function openLink(link: string) {
     if (link.startsWith("http")) {
@@ -20,6 +19,5 @@ export function openAnchorLink(e: MouseEvent) {
 }
 
 export function openContainerLogFile() {
-    const logPath = path.join(path.join(WINBOAT_DIR, "container.log"));
-    shell.openPath(logPath);
+    shell.openPath(CONTAINER_LOG_FILE);
 }

--- a/src/renderer/utils/openLink.ts
+++ b/src/renderer/utils/openLink.ts
@@ -1,4 +1,6 @@
 const { shell }: typeof import("@electron/remote") = require("@electron/remote");
+const path: typeof import("path") = require("node:path");
+import { WINBOAT_DIR } from "../lib/constants";
 
 export function openLink(link: string) {
     if (link.startsWith("http")) {
@@ -15,4 +17,9 @@ export function openAnchorLink(e: MouseEvent) {
     if (href) {
         openLink(href);
     }
+}
+
+export function openContainerLogFile() {
+    const logPath = path.join(path.join(WINBOAT_DIR, "container.log"));
+    shell.openPath(logPath);
 }

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -55,9 +55,14 @@
                         </p>
                     </div>
 
-                    <p v-if="winboat.lastContainerError.value" class="!my-2 text-sm text-red-400 max-w-md">
+                    <button
+                        v-if="winboat.lastContainerError.value"
+                        @click="openContainerLogFile()"
+                        class="!my-2 text-sm text-red-400 max-w-md text-left hover:text-red-300 hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit transition"
+                    >
                         {{ winboat.lastContainerError.value }}
-                    </p>
+                        <Icon icon="lucide:external-link" class="inline size-3.5 ml-0.5 translate-y-[-1px]" />
+                    </button>
                 </div>
             </div>
 
@@ -197,7 +202,7 @@ import { type ComposeConfig } from "../../types";
 import { WINDOWS_VERSIONS } from "../lib/constants";
 import { Icon } from "@iconify/vue";
 import { capitalizeFirstLetter } from "../utils/capitalize";
-import { openAnchorLink } from "../utils/openLink";
+import { openAnchorLink, openContainerLogFile } from "../utils/openLink";
 
 const winboat = Winboat.getInstance();
 const compose = ref<ComposeConfig | null>(null);

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -42,8 +42,10 @@
                     <div
                         class="flex flex-row items-center gap-1.5"
                         :class="{
+                            'text-red-500':
+                                winboat.containerStatus.value === ContainerStatus.EXITED ||
+                                winboat.containerStatus.value === ContainerStatus.ERROR,
                             'text-green-500': winboat.containerStatus.value === ContainerStatus.RUNNING,
-                            'text-red-500': winboat.containerStatus.value === ContainerStatus.EXITED,
                             'text-yellow-500': winboat.containerStatus.value === ContainerStatus.PAUSED,
                             'text-orange-500': winboat.containerStatus.value === ContainerStatus.UNKNOWN,
                             'text-gray-500': winboat.containerStatus.value === ContainerStatus.CREATED,
@@ -51,18 +53,23 @@
                     >
                         <Icon class="size-7 scale-90" icon="octicon:container-16"></Icon>
                         <p class="!my-0 font-semibold text-lg">
-                            Container - {{ capitalizeFirstLetter(winboat.containerStatus.value) }}
+                            Container -
+                            {{
+                                winboat.containerStatus.value === ContainerStatus.ERROR
+                                    ? "Failed to Start"
+                                    : capitalizeFirstLetter(winboat.containerStatus.value)
+                            }}
+                            <button
+                                v-if="winboat.containerStatus.value === ContainerStatus.ERROR"
+                                @click="openContainerLogFile()"
+                                class="text-sm"
+                            >
+                                (check logs
+                                <Icon icon="lucide:external-link" class="inline size-3.5 ml-0.5 translate-y-[-1px]" />
+                                )
+                            </button>
                         </p>
                     </div>
-
-                    <button
-                        v-if="winboat.lastContainerError.value"
-                        @click="openContainerLogFile()"
-                        class="!my-2 text-sm text-red-400 max-w-md text-left hover:text-red-300 hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit transition"
-                    >
-                        {{ winboat.lastContainerError.value }}
-                        <Icon icon="lucide:external-link" class="inline size-3.5 ml-0.5 translate-y-[-1px]" />
-                    </button>
                 </div>
             </div>
 
@@ -74,7 +81,8 @@
                     v-if="
                         winboat.containerStatus.value === ContainerStatus.EXITED ||
                         winboat.containerStatus.value === ContainerStatus.CREATED ||
-                        winboat.containerStatus.value === ContainerStatus.UNKNOWN
+                        winboat.containerStatus.value === ContainerStatus.UNKNOWN ||
+                        winboat.containerStatus.value === ContainerStatus.ERROR
                     "
                     @click="winboat.startContainer()"
                 >

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -54,6 +54,10 @@
                             Container - {{ capitalizeFirstLetter(winboat.containerStatus.value) }}
                         </p>
                     </div>
+
+                    <p v-if="winboat.lastContainerError.value" class="!my-2 text-sm text-red-400 max-w-md">
+                        {{ winboat.lastContainerError.value }}
+                    </p>
                 </div>
             </div>
 


### PR DESCRIPTION
Hi,

I had two issues with Winboat when using it on my steam deck. I am using `podman` and `podman-compose` installed via `brew` which works fine.

However, sometimes the podman container gets broken due to the USB passthrough (e.g. when USB devices have been unplugged in the meantime).
When then trying to start the container in Winboat, there is just an endless spinner without error message.
But manually trying to start it shows this:
```
(deck@steamdeck ~)$ podman ps -a
CONTAINER ID  IMAGE                        COMMAND     CREATED     STATUS                 PORTS                                                                                                                                  NAMES
06cdeee91076  ghcr.io/dockur/windows:5.14              4 days ago  Exited (0) 4 days ago  127.0.0.1:39203->3389/tcp, 127.0.0.1:38997->7148/tcp, 127.0.0.1:37031->7149/tcp, 127.0.0.1:39639->8006/tcp, 127.0.0.1:37213->3389/udp  WinBoat

(deck@steamdeck ~)$ podman start 06cdeee91076
Error: unable to start container "06cdeee9107683c1f2c645dca82cd204d08a9c8d299df2a7c0cf98543d3ecdc5": crun: cannot stat `/dev/bus/usb/001/022`: No such file or directory: OCI runtime attempted to invoke a command that was not found
```

Additionally, if the container was removed for some reason, Winboat will not detect this on start and show the initial setup screen on start, even though all the files of the windows installation still exist.  
When manually starting the container via the compose file, everything works fine again.


So this change includes the following:

1. Detect existing installation files and don't show initial setup screen if there is currently no existing container.
2. Recreate the container if it runs into errors due to USB device mapping
3. Recreate the container from the compose file if installation files exist
4. Don't show endless spinner for some actions if they fail
5. Show error message in GUI if starting of the container fails even after trying to recreate it


These changes are related to:

- #663 
- #569 
- #502
- #591 
- #218
- #533 (<- this change might also be sensible for podman)
