### PR TITLE
Update Windows Docker image version to v6.00

### DIFF
--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -8,7 +8,7 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:5.16",
+            image: "ghcr.io/dockur/windows:6.00",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -8,7 +8,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:5.16",
+            image: "ghcr.io/dockur/windows:6.00",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",


### PR DESCRIPTION
Update Windows Docker image version to v6.00

This contains a lot of improvements, and especially around the networking code. A lot of edge-cases have been solved, for example the handling of non-standard MTU values and better iptable rules for NAT. But also other parts like the image installation, are much more robust now.

I would also suggest removing the `NETWORK: "user"` setting from the Podman compose. Im not really sure why it was ever added, but Im pretty sure it will not be needed anymore in v6.00. But I did not make that change in this pull request, because I dont want to break anything if it was added for a good reason?

I also added documentation now that lists every possible environment variable, see here: https://github.com/dockur/windows/blob/master/docs/environment.md It might come in handy for your developers one day.