### PR TITLE
chore: Migrate the Guest Server Borked page from Rentry

### DIFF
--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -30,7 +30,7 @@
                             <a
                                 v-if="!winboat.isOnline.value"
                                 title="Get Help"
-                                href="https://rentry.org/winboat_guest_server_borked"
+                                href="https://winboat.app/guest-server-borked"
                                 @click="openAnchorLink"
                                 class="text-red-400 hover:text-red-500 hover:underline inline-flex translate-y-1 transition"
                             >


### PR DESCRIPTION
NOTICE: Merge https://github.com/TibixDev/winboat-web/pull/8 before this!

This moves the Guest Server broken page from https://rentry.org to the website page https://winboat.app/guest-server-borked

The page returns 404 in the video because the page has not been merged into the website.

https://github.com/user-attachments/assets/b25fa36a-4f14-4692-9ce5-4e9d1c15e0b5