### PR TITLE
feat: Respect XDG_DATA_HOME for storing app-related files instead of ~/.winboat

### DIFF
--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -153,7 +153,7 @@ export class WinboatConfig {
             if (!writeDefault) return null;
             // Also the create the directory because we're not guaranteed to have it
             if (!fs.existsSync(WINBOAT_DIR)) {
-                fs.mkdirSync(WINBOAT_DIR);
+                fs.mkdirSync(WINBOAT_DIR, { recursive: true });
             }
 
             fs.writeFileSync(WinboatConfig.configPath, JSON.stringify(defaultConfig, null, 4), "utf-8");

--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -1,8 +1,11 @@
 const os: typeof import("os") = require("node:os");
+const process: typeof import("process") = require("node:process");
 const path: typeof import("path") = require("node:path");
 
-// Should be {home}/.winboat
-export const WINBOAT_DIR = path.join(os.homedir(), ".winboat");
+// Should be {XDG_DATA_HOME}/winboat-app or {home}/.local/share/winboat-app if missing
+export const WINBOAT_DIR = process.env.XDG_DATA_HOME ?
+    path.join(process.env.XDG_DATA_HOME, "winboat-app") :
+    path.join(os.homedir(), ".local", "share", "winboat-app");
 export const DEFAULT_HOMEBREW_DIR = path.join(os.homedir(), "../linuxbrew/.linuxbrew/bin");
 
 export const WINDOWS_VERSIONS = {

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -69,7 +69,7 @@ export class InstallManager {
 
         // Ensure the .winboat directory exists
         if (!fs.existsSync(WINBOAT_DIR)) {
-            fs.mkdirSync(WINBOAT_DIR);
+            fs.mkdirSync(WINBOAT_DIR, { recursive: true });
             logger.info(`Created WinBoat directory: ${WINBOAT_DIR}`);
         }
 


### PR DESCRIPTION
This PR aims to change the `~/.winboat` directory for app related files to `$XDG_DATA_HOME/winboat-app`. While not a 100% perfect solution (we could split app related files into many more XDG dirs), it respects the spec enough that most people should be happy, or at least happier than having a dot folder in their home.

❗Needs migration code for existing users if we decide that 1.0 will be backwards compatible

Closes #77