### PR TITLE
Update Windows Docker image version to v6.01

### DIFF
--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -14,7 +14,7 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.00",
+            image: "ghcr.io/dockur/windows:6.01",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -14,7 +14,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.00",
+            image: "ghcr.io/dockur/windows:6.01",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",


### PR DESCRIPTION
Update Windows Docker image version to v6.01

Contains a lot of Podman networking related changes:

- Fixed NAT port forwarding in rootless Podman, where published container ports could reach the container namespace but were not forwarded onward to the VM.
- Added explicit DNAT handling for VM ports instead of relying on the container engine’s existing forwarding rules.
- Prefer nftables under Podman and legacy iptables under Docker, with automatic fallback when the preferred backend cannot access the active ruleset.
- Added a dedicated "QEMU_DNAT" chain that preserves container-owned TCP ports and forwards all remaining protocols and ports to the VM.
- Changed unqualified port entries to TCP-only; UDP forwarding now requires an explicit "/udp" suffix.
- Added inspection of existing "PREROUTING", "POSTROUTING", "FORWARD", and mangle rules, with warnings for conflicting DNAT, REDIRECT, DROP, or REJECT rules.
- Added debug output showing the existing rules that may interfere with VM networking.
- Changed iptables backend detection to test actual NAT ruleset access through both "iptables" and "iptables-save", rather than trusting the selected binary.
- Added bidirectional TCP MSS clamping for traffic entering and leaving the VM to prevent MTU-related connection stalls.
- Broadened forwarding rules to permit traffic between the VM bridge and any external interface instead of depending on established-connection matching.
- Changed masquerading to apply to the configured VM subnet leaving through any non-bridge interface.

So https://github.com/TibixDev/winboat/pull/813 should be good to go.

Another notable feature is audio support in noVNC, and much more helpful error messages when the .iso download fails.