### PR TITLE
fix: pass FreeRDP credentials over stdin

### DIFF
--- a/src/renderer/lib/exec-helper.ts
+++ b/src/renderer/lib/exec-helper.ts
@@ -14,6 +14,27 @@ export type ExecFileAsyncError = {
 
 export const execFileAsync = promisify(execFile);
 
+export function execFileWithStdin(
+    file: string,
+    args: string[],
+    stdin: string,
+): Promise<{
+    stdout: string;
+    stderr: string;
+}> {
+    return new Promise((resolve, reject) => {
+        const child = execFile(file, args, (error, stdout, stderr) => {
+            if (error) {
+                Object.assign(error, { stdout, stderr });
+                reject(error);
+                return;
+            }
+            resolve({ stdout, stderr });
+        });
+        child.stdin?.end(stdin);
+    });
+}
+
 export function stringifyExecFile(file: string, args: string[]): string {
     let result = `${file}`;
     for (const arg of args) {

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -4,7 +4,7 @@ import YAML from "yaml";
 import type { ComposeConfig, CustomAppCallbacks, GuestServerVersion, Metrics, WinApp } from "../../types";
 import { AppIcons } from "../data/appicons";
 import { InternalApps } from "../data/internalapps";
-import { getFreeRDP } from "../utils/getFreeRDP";
+import { buildFreeRDPConnectionArgs, getFreeRDP } from "../utils/getFreeRDP";
 import { guestServerUpdateZipPath, guestUpdaterAuthHeaders } from "../utils/guestServer";
 import { setIntervalImmediately } from "../utils/interval";
 import { createLogger } from "../utils/log";
@@ -713,7 +713,7 @@ export class Winboat {
                 useOriginalIfUndefinedOrNull(replacementArgs?.find(r => argStr === r.original?.trim())?.newArg, argStr),
             )
             .concat(newArgs);
-        let args = [`/u:${username}`, `/p:${password}`, `/v:127.0.0.1`, `/port:${HOST_RDP_PORT}`, ...combinedArgs];
+        let args = [...buildFreeRDPConnectionArgs(username, HOST_RDP_PORT), ...combinedArgs];
 
         if (app.Path == InternalApps.WINDOWS_DESKTOP) {
             args = args.concat([
@@ -745,7 +745,7 @@ export class Winboat {
         try {
             const safeToLogArgs = freeRDPInstallation.stringifyExec(args).replace(/\/p:[^ ]+/g, "/p:********");
             logger.info(`Launch FreeRDP with command:\n${safeToLogArgs}`);
-            await freeRDPInstallation.exec(args);
+            await freeRDPInstallation.execWithStdin(args, `${password}\n`);
         } catch (e) {
             const execError = e as ExecFileAsyncError;
             const ERRINFO_RPC_INITIATED_DISCONNECT = 0x00000001;

--- a/src/renderer/utils/getFreeRDP.ts
+++ b/src/renderer/utils/getFreeRDP.ts
@@ -1,4 +1,4 @@
-import { execFileAsync, stringifyExecFile } from "../lib/exec-helper";
+import { execFileAsync, execFileWithStdin, stringifyExecFile } from "../lib/exec-helper";
 
 export class FreeRDPInstallation {
     file: string;
@@ -16,9 +16,23 @@ export class FreeRDPInstallation {
         return execFileAsync(this.file, this.defaultArgs.concat(args));
     }
 
+    execWithStdin(
+        args: string[],
+        stdin: string,
+    ): Promise<{
+        stdout: string;
+        stderr: string;
+    }> {
+        return execFileWithStdin(this.file, this.defaultArgs.concat(args), stdin);
+    }
+
     stringifyExec(args: string[]): string {
         return stringifyExecFile(this.file, this.defaultArgs.concat(args));
     }
+}
+
+export function buildFreeRDPConnectionArgs(username: string, port: number): string[] {
+    return [`/u:${username}`, "/from-stdin:force", "/v:127.0.0.1", `/port:${port}`];
 }
 
 const freeRDPInstallations = [

--- a/test/freeRDP-credentials.test.ts
+++ b/test/freeRDP-credentials.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildFreeRDPConnectionArgs, FreeRDPInstallation } from "../src/renderer/utils/getFreeRDP";
+
+describe("FreeRDP credential handling", () => {
+    test("requests stdin authentication without placing a password in argv", () => {
+        const args = buildFreeRDPConnectionArgs("winboat-user", 3389);
+
+        expect(args).toEqual(["/u:winboat-user", "/from-stdin:force", "/v:127.0.0.1", "/port:3389"]);
+        expect(args.some(arg => arg.startsWith("/p:"))).toBe(false);
+    });
+
+    test("delivers secrets through stdin rather than child argv", async () => {
+        const installation = new FreeRDPInstallation(process.execPath);
+        const script = [
+            "let input = '';",
+            "process.stdin.setEncoding('utf8');",
+            "process.stdin.on('data', chunk => input += chunk);",
+            "process.stdin.on('end', () => console.log(JSON.stringify({ argv: process.argv.slice(1), input })));",
+        ].join("");
+
+        const { stdout } = await installation.execWithStdin(["-e", script, "visible-argument"], "private-password\n");
+        const result = JSON.parse(stdout) as { argv: string[]; input: string };
+
+        expect(result.argv).toContain("visible-argument");
+        expect(result.argv).not.toContain("private-password");
+        expect(result.input).toBe("private-password\n");
+    });
+
+    test("the production launcher uses stdin instead of a password argument", async () => {
+        const source = await Bun.file(new URL("../src/renderer/lib/winboat.ts", import.meta.url)).text();
+
+        expect(source).toContain("buildFreeRDPConnectionArgs(username, HOST_RDP_PORT)");
+        expect(source).toContain("execWithStdin(args, `${password}\\n`)");
+        expect(source).not.toContain("`/p:${password}`");
+    });
+});


### PR DESCRIPTION
## Summary

- stop placing the saved Windows password in FreeRDP's process arguments
- use FreeRDP 3's `/from-stdin:force` option and write the password to the child process stdin
- preserve existing stdout/stderr and exit-code handling
- add focused tests covering argv construction, real stdin delivery, and production launch wiring

## Why

The current launcher passes `/p:<password>` to FreeRDP. Command-line arguments can be observed through process inspection tools while the RDP client is running. Passing the password over stdin avoids exposing it in the process command line.

## Verification

- `bun test test/freeRDP-credentials.test.ts` — 3 passed
- `bun test` — 3 passed
- `bunx prettier --check src/renderer/lib/exec-helper.ts src/renderer/utils/getFreeRDP.ts src/renderer/lib/winboat.ts test/freeRDP-credentials.test.ts`
- `bunx tsc --noEmit -p src/main/tsconfig.json`
- `bun scripts/build.ts`

The renderer type check still reports existing dependency/global declaration errors and an existing `ConfigCard.vue` arity error; none are in the files changed here.
