### PR TITLE
fix: configure NVIDIA Helios containers

### DIFF
--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -76,7 +76,7 @@ export const GUEST_QMP_PORT = 7149;
 export const GUEST_UPDATE_PORT = 7150;
 export const GUEST_RDP_PORT = 3389;
 
-export const HELIOS_DOCKUR_IMAGE = "ghcr.io/winboat-org/helios-windows:6.03.1";
+export const HELIOS_DOCKUR_IMAGE = "ghcr.io/winboat-org/helios-windows:6.03.2";
 export const DEFAULT_GPU_VRAM_GB = 4;
 export const GPU_VRAM_RESERVE_GB = 2;
 export const UNKNOWN_GPU_VRAM_MAX_GB = 16;

--- a/src/renderer/lib/gpu-container.ts
+++ b/src/renderer/lib/gpu-container.ts
@@ -1,0 +1,111 @@
+import type { ComposeConfig } from "../../types";
+import { requiresNvidiaContainerSupport, type RenderDevice } from "./gpu";
+
+type WindowsService = ComposeConfig["services"]["windows"];
+type DeviceReservation = NonNullable<
+    NonNullable<NonNullable<NonNullable<WindowsService["deploy"]>["resources"]>["reservations"]>["devices"]
+>[number];
+
+const NVIDIA_DRIVER = "nvidia";
+const NVIDIA_GRAPHICS_CAPABILITY = "graphics";
+const NVIDIA_RENDER_ENVIRONMENT = {
+    __NV_PRIME_RENDER_OFFLOAD: "1",
+    __EGL_VENDOR_LIBRARY_FILENAMES: "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+    __GLX_VENDOR_LIBRARY_NAME: "nvidia",
+    __VK_LAYER_NV_optimus: "NVIDIA_only",
+    VK_ICD_FILENAMES: "/etc/vulkan/icd.d/nvidia_icd.json",
+    GBM_BACKEND: "nvidia-drm",
+    GBM_BACKENDS_PATH: "/usr/lib/gbm:/usr/lib/x86_64-linux-gnu/gbm",
+} as const;
+
+const NVIDIA_ENVIRONMENT_KEYS = ["NVIDIA_DRIVER_CAPABILITIES", ...Object.keys(NVIDIA_RENDER_ENVIRONMENT)];
+
+function getNvidiaReservations(service: WindowsService): DeviceReservation[] {
+    return (service.deploy?.resources?.reservations?.devices || []).filter(
+        reservation => reservation.driver === NVIDIA_DRIVER,
+    );
+}
+
+function hasNvidiaGraphicsCapability(value?: string): boolean {
+    const capabilities = new Set((value || "").split(",").map(capability => capability.trim().toLowerCase()));
+    return capabilities.has("all") || capabilities.has(NVIDIA_GRAPHICS_CAPABILITY);
+}
+
+function nvidiaRenderEnvironmentNeedsUpdate(service: WindowsService): boolean {
+    return Object.entries(NVIDIA_RENDER_ENVIRONMENT).some(([key, value]) => service.environment[key] !== value);
+}
+
+export function gpuContainerConfigNeedsUpdate(service: WindowsService, device?: RenderDevice): boolean {
+    const nvidiaReservations = getNvidiaReservations(service);
+
+    if (!requiresNvidiaContainerSupport(device)) {
+        return (
+            nvidiaReservations.length > 0 || NVIDIA_ENVIRONMENT_KEYS.some(key => service.environment[key] !== undefined)
+        );
+    }
+
+    const reservation = nvidiaReservations[0];
+    return (
+        !device?.nvidiaUuid ||
+        nvidiaReservations.length !== 1 ||
+        reservation.device_ids?.length !== 1 ||
+        reservation.device_ids[0] !== device.nvidiaUuid ||
+        !reservation.capabilities.includes("gpu") ||
+        !hasNvidiaGraphicsCapability(service.environment.NVIDIA_DRIVER_CAPABILITIES) ||
+        nvidiaRenderEnvironmentNeedsUpdate(service)
+    );
+}
+
+export function configureGpuContainer(service: WindowsService, device: RenderDevice): void {
+    const reservations = service.deploy?.resources?.reservations?.devices || [];
+    const nonNvidiaReservations = reservations.filter(reservation => reservation.driver !== NVIDIA_DRIVER);
+
+    if (!requiresNvidiaContainerSupport(device)) {
+        for (const key of NVIDIA_ENVIRONMENT_KEYS) delete service.environment[key];
+
+        const composeReservations = service.deploy?.resources?.reservations;
+        if (!composeReservations) return;
+
+        if (nonNvidiaReservations.length) {
+            composeReservations.devices = nonNvidiaReservations;
+            return;
+        }
+
+        delete composeReservations.devices;
+        if (Object.keys(composeReservations).length === 0) delete service.deploy?.resources?.reservations;
+        if (service.deploy?.resources && Object.keys(service.deploy.resources).length === 0) {
+            delete service.deploy.resources;
+        }
+        if (service.deploy && Object.keys(service.deploy).length === 0) delete service.deploy;
+        return;
+    }
+
+    if (!device.nvidiaUuid) {
+        throw new Error(`Could not map ${device.path} to an NVIDIA GPU UUID through nvidia-smi.`);
+    }
+
+    const currentCapabilities = service.environment.NVIDIA_DRIVER_CAPABILITIES;
+    if (!hasNvidiaGraphicsCapability(currentCapabilities)) {
+        const capabilities = new Set(
+            (currentCapabilities || "")
+                .split(",")
+                .map(capability => capability.trim().toLowerCase())
+                .filter(Boolean),
+        );
+        capabilities.add(NVIDIA_GRAPHICS_CAPABILITY);
+        service.environment.NVIDIA_DRIVER_CAPABILITIES = [...capabilities].join(",");
+    }
+    Object.assign(service.environment, NVIDIA_RENDER_ENVIRONMENT);
+
+    service.deploy ??= {};
+    service.deploy.resources ??= {};
+    service.deploy.resources.reservations ??= {};
+    service.deploy.resources.reservations.devices = [
+        ...nonNvidiaReservations,
+        {
+            driver: NVIDIA_DRIVER,
+            device_ids: [device.nvidiaUuid],
+            capabilities: ["gpu"],
+        },
+    ];
+}

--- a/src/renderer/lib/gpu.ts
+++ b/src/renderer/lib/gpu.ts
@@ -1,5 +1,6 @@
 import { execFileAsync } from "./exec-helper";
 import { GPU_VRAM_RESERVE_GB, MAX_GPU_VRAM_GB, UNKNOWN_GPU_VRAM_MAX_GB } from "./constants";
+import YAML from "yaml";
 
 const fs: typeof import("node:fs") = require("node:fs");
 const path: typeof import("node:path") = require("node:path");
@@ -8,8 +9,23 @@ export type RenderDevice = {
     path: string;
     name: string;
     driver: string;
+    pciId?: string;
     vramGB?: number;
+    nvidiaUuid?: string;
 };
+
+type NvidiaGpuInfo = {
+    vramBytes: number;
+    uuid?: string;
+};
+
+export function requiresNvidiaContainerSupport(device?: RenderDevice): boolean {
+    return device?.driver.toLowerCase() === "nvidia";
+}
+
+export function shouldCheckNvidiaContainerSupport(gpuEnabled: boolean, device?: RenderDevice): boolean {
+    return gpuEnabled && requiresNvidiaContainerSupport(device);
+}
 
 export function getGpuVramMaxGB(hostVramGB?: number): number {
     if (hostVramGB === undefined) return UNKNOWN_GPU_VRAM_MAX_GB;
@@ -40,28 +56,38 @@ function readSysfsVramBytes(sysfsPath: string): number {
     }
 }
 
-async function readNvidiaVramBytes(sysfsPath: string, properties: Record<string, string>): Promise<number> {
+async function readNvidiaGpuInfo(
+    sysfsPath: string,
+    properties: Record<string, string>,
+): Promise<NvidiaGpuInfo | undefined> {
     let pciAddress = properties.PCI_SLOT_NAME;
 
     if (!pciAddress) {
         try {
             pciAddress = path.basename(fs.realpathSync(sysfsPath));
         } catch {
-            return 0;
+            return undefined;
         }
     }
 
     try {
         const { stdout } = await execFileAsync("nvidia-smi", [
             `--id=${pciAddress}`,
-            "--query-gpu=memory.total",
+            "--query-gpu=memory.total,uuid",
             "--format=csv,noheader,nounits",
         ]);
-        const vramMiB = Number(stdout.trim());
+        const [vramText, uuid] = stdout
+            .trim()
+            .split(",", 2)
+            .map(value => value.trim());
+        const vramMiB = Number(vramText);
 
-        return Number.isFinite(vramMiB) && vramMiB > 0 ? vramMiB * 1024 ** 2 : 0;
+        return {
+            vramBytes: Number.isFinite(vramMiB) && vramMiB > 0 ? vramMiB * 1024 ** 2 : 0,
+            ...(uuid?.startsWith("GPU-") ? { uuid } : {}),
+        };
     } catch {
-        return 0;
+        return undefined;
     }
 }
 
@@ -85,16 +111,20 @@ async function inspectRenderDevice(devicePath: string): Promise<RenderDevice> {
     const pciId = properties.PCI_ID;
     const name = [vendor, model].filter(Boolean).join(" ") || (pciId ? `PCI GPU ${pciId}` : path.basename(devicePath));
     let vramBytes = readSysfsVramBytes(sysfsPath);
+    let nvidiaInfo: NvidiaGpuInfo | undefined;
 
-    if (vramBytes <= 0 && (properties.DRIVER === "nvidia" || pciId?.toUpperCase().startsWith("10DE:"))) {
-        vramBytes = await readNvidiaVramBytes(sysfsPath, properties);
+    if (properties.DRIVER === "nvidia" || pciId?.toUpperCase().startsWith("10DE:")) {
+        nvidiaInfo = await readNvidiaGpuInfo(sysfsPath, properties);
+        if (vramBytes <= 0) vramBytes = nvidiaInfo?.vramBytes || 0;
     }
 
     return {
         path: devicePath,
         name,
         driver: properties.DRIVER || "unknown",
+        ...(pciId ? { pciId } : {}),
         ...(vramBytes > 0 ? { vramGB: Math.max(1, Math.round(vramBytes / 1024 ** 3)) } : {}),
+        ...(nvidiaInfo?.uuid ? { nvidiaUuid: nvidiaInfo.uuid } : {}),
     };
 }
 
@@ -114,4 +144,73 @@ export async function getRenderDevices(): Promise<RenderDevice[]> {
     }
 
     return Promise.all(paths.map(inspectRenderDevice));
+}
+
+type CdiSpec = {
+    kind?: string;
+    devices?: Array<{ name?: string }>;
+};
+
+export function nvidiaCdiSpecProvidesGpu(text: string, nvidiaUuid: string): boolean {
+    try {
+        return YAML.parseAllDocuments(text).some(document => {
+            if (document.errors.length) return false;
+
+            const spec = document.toJS() as CdiSpec | null;
+            if (spec?.kind !== "nvidia.com/gpu") return false;
+
+            return spec.devices?.some(device => device.name === nvidiaUuid) === true;
+        });
+    } catch {
+        return false;
+    }
+}
+
+function hasNvidiaCdiDevice(specDirs: string[], nvidiaUuid: string): boolean {
+    for (const specDir of specDirs) {
+        let entries: import("node:fs").Dirent[];
+
+        try {
+            entries = fs.readdirSync(specDir, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+
+        for (const entry of entries) {
+            if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+
+            try {
+                const text = fs.readFileSync(path.join(specDir, entry.name), "utf8");
+                if (nvidiaCdiSpecProvidesGpu(text, nvidiaUuid)) return true;
+            } catch {
+                // Ignore stale or unreadable CDI entries and continue checking the daemon's other spec directories.
+            }
+        }
+    }
+
+    return false;
+}
+
+export async function hasNvidiaContainerSupport(nvidiaUuid: string): Promise<boolean> {
+    try {
+        const { stdout } = await execFileAsync("docker", ["info", "--format", "{{json .Runtimes}}"]);
+        const runtimes = JSON.parse(stdout) as Record<string, unknown>;
+        if (Object.hasOwn(runtimes, "nvidia")) return true;
+    } catch {
+        // Docker 29 can use NVIDIA CDI devices without a named nvidia runtime.
+    }
+
+    try {
+        const { stdout } = await execFileAsync("docker", ["info", "--format", "{{json .CDISpecDirs}}"]);
+        const specDirs = JSON.parse(stdout) as unknown;
+        return (
+            Array.isArray(specDirs) &&
+            hasNvidiaCdiDevice(
+                specDirs.filter(value => typeof value === "string"),
+                nvidiaUuid,
+            )
+        );
+    } catch {
+        return false;
+    }
 }

--- a/src/renderer/lib/install.ts
+++ b/src/renderer/lib/install.ts
@@ -15,6 +15,8 @@ import { Winboat } from "./winboat";
 import { ContainerManager } from "./containers/container";
 import { WinboatConfig } from "./config";
 import { ContainerRuntimes, createContainer } from "./containers/common";
+import { configureGpuContainer } from "./gpu-container";
+import { getRenderDevices, hasNvidiaContainerSupport, shouldCheckNvidiaContainerSupport } from "./gpu";
 
 const fs: typeof import("fs") = require("fs");
 const path: typeof import("path") = require("path");
@@ -125,6 +127,21 @@ export class InstallManager {
                 throw new Error(`GPU video memory must be between 1 and ${MAX_GPU_VRAM_GB} GB.`);
             }
 
+            const renderDevice = (await getRenderDevices()).find(device => device.path === this.conf.renderDevice);
+            if (!renderDevice) {
+                throw new Error(`Could not inspect the selected GPU render device: ${this.conf.renderDevice}`);
+            }
+            if (shouldCheckNvidiaContainerSupport(this.conf.gpuEnabled, renderDevice)) {
+                if (!renderDevice.nvidiaUuid) {
+                    throw new Error(`Could not map ${renderDevice.path} to an NVIDIA GPU UUID through nvidia-smi.`);
+                }
+                if (!(await hasNvidiaContainerSupport(renderDevice.nvidiaUuid))) {
+                    throw new Error(
+                        "NVIDIA Container Toolkit is not exposing this GPU to Docker. Configure the NVIDIA runtime or CDI support before enabling Helios on this GPU.",
+                    );
+                }
+            }
+
             const vramBytes = this.conf.gpuVramGB * 1024 ** 3;
             composeContent.services.windows.image = HELIOS_DOCKUR_IMAGE;
             Object.assign(composeContent.services.windows.environment, {
@@ -139,6 +156,7 @@ export class InstallManager {
             if (!composeContent.services.windows.devices.includes(this.conf.renderDevice)) {
                 composeContent.services.windows.devices.push(this.conf.renderDevice);
             }
+            configureGpuContainer(composeContent.services.windows, renderDevice);
         }
 
         // Boot image mapping

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -84,23 +84,15 @@
                 </ConfigCard>
 
                 <!-- Shared Folder Location -->
-                <ConfigCard
-                    v-if="shareFolder"
-                    icon="mdi:folder-cog"
-                    title="Shared Folder Location"
-                    type="custom"
-                >
+                <ConfigCard v-if="shareFolder" icon="mdi:folder-cog" title="Shared Folder Location" type="custom">
                     <template v-slot:desc>
                         <span v-if="sharedFolderPath">
-                            Currently sharing: <span class="font-mono bg-neutral-700 rounded-md px-1 py-0.5">{{ sharedFolderPath }}</span>
+                            Currently sharing:
+                            <span class="font-mono bg-neutral-700 rounded-md px-1 py-0.5">{{ sharedFolderPath }}</span>
                         </span>
-                        <span v-else>
-                            Select a folder to share with Windows
-                        </span>
+                        <span v-else> Select a folder to share with Windows </span>
                     </template>
-                    <x-button @click="selectSharedFolder">
-                        Browse
-                    </x-button>
+                    <x-button @click="selectSharedFolder"> Browse </x-button>
                 </ConfigCard>
 
                 <!-- Auto Start Container -->
@@ -391,9 +383,9 @@
                     v-model:value="wbConfig.config.multiMonitor"
                 >
                     <template v-slot:desc>
-                        Controls how multiple monitors are handled. MultiMon creates separate displays for each
-                        monitor, while Span stretches the display across all monitors. Note: Span or MultiMon may
-                        work better depending on your setup.
+                        Controls how multiple monitors are handled. MultiMon creates separate displays for each monitor,
+                        while Span stretches the display across all monitors. Note: Span or MultiMon may work better
+                        depending on your setup.
                     </template>
                 </ConfigCard>
 
@@ -485,7 +477,14 @@ import { Winboat } from "../lib/winboat";
 import { ContainerRuntimes, ContainerStatus } from "../lib/containers/common";
 import type { ComposeConfig } from "../../types";
 import { getSpecs } from "../lib/specs";
-import { getGpuVramMaxGB, getRenderDevices, type RenderDevice } from "../lib/gpu";
+import {
+    getGpuVramMaxGB,
+    getRenderDevices,
+    hasNvidiaContainerSupport,
+    shouldCheckNvidiaContainerSupport,
+    type RenderDevice,
+} from "../lib/gpu";
+import { configureGpuContainer, gpuContainerConfigNeedsUpdate } from "../lib/gpu-container";
 import { Icon } from "@iconify/vue";
 import { MultiMonitorMode, RdpArg, WinboatConfig } from "../lib/config";
 import { USBManager, type PTSerializableDeviceInfo } from "../lib/usbmanager";
@@ -519,8 +518,19 @@ const origGpuVramGB = ref(DEFAULT_GPU_VRAM_GB);
 const renderDevices = ref<RenderDevice[]>([]);
 const renderDevice = ref("");
 const origRenderDevice = ref("");
+const nvidiaContainerSupportAvailable = ref(false);
 const selectedGpu = computed(() => renderDevices.value.find(device => device.path === renderDevice.value));
 const gpuVramMaxGB = computed(() => getGpuVramMaxGB(selectedGpu.value?.vramGB));
+const nvidiaGpuError = computed(() => {
+    if (!shouldCheckNvidiaContainerSupport(gpuEnabled.value, selectedGpu.value)) return "";
+    if (!selectedGpu.value?.nvidiaUuid) {
+        return "WinBoat could not map this render node to an NVIDIA GPU through nvidia-smi";
+    }
+    if (!nvidiaContainerSupportAvailable.value) {
+        return "NVIDIA Container Toolkit is not exposing this GPU to Docker through a runtime or CDI";
+    }
+    return "";
+});
 const shareFolder = ref(false);
 const origShareFolder = ref(false);
 const sharedFolderPath = ref("");
@@ -543,6 +553,7 @@ const usbManager = USBManager.getInstance();
 // Constants
 const USB_BUS_PATH = "/dev/bus/usb:/dev/bus/usb";
 const RENDER_DEVICE_MAPPING = /^\/dev\/dri\/renderD\d+(?::|$)/;
+let nvidiaSupportCheckSequence = 0;
 
 onMounted(async () => {
     await assignValues();
@@ -569,6 +580,7 @@ async function assignValues() {
         } catch (error) {
             console.error("Failed to detect GPU render devices", error);
             renderDevices.value = [];
+            nvidiaContainerSupportAvailable.value = false;
         }
 
         renderDevice.value = environment.RENDERNODE || findConfiguredRenderDevice();
@@ -635,6 +647,7 @@ async function saveCompose() {
         });
         windows.devices = windows.devices.filter(device => !isRenderDeviceMapping(device));
         windows.devices.push(renderDevice.value);
+        configureGpuContainer(windows, selectedGpu.value!);
     }
 
     // Remove any existing shared volume
@@ -751,6 +764,10 @@ const errors = computed(() => {
         errCollection.push(`GPU video memory must be between 1 and ${gpuVramMaxGB.value} GB`);
     }
 
+    if (gpuEnabled.value && nvidiaGpuError.value) {
+        errCollection.push(nvidiaGpuError.value);
+    }
+
     return errCollection;
 });
 
@@ -775,11 +792,16 @@ const usbPassthroughDisabled = computed(() => {
 });
 
 const saveButtonDisabled = computed(() => {
+    const gpuContainerConfigChanged =
+        gpuEnabled.value &&
+        !!compose.value &&
+        gpuContainerConfigNeedsUpdate(compose.value.services.windows, selectedGpu.value);
     const hasResourceChanges =
         origNumCores.value !== numCores.value ||
         origRamGB.value !== ramGB.value ||
         (gpuEnabled.value &&
             (origGpuVramGB.value !== gpuVramGB.value || origRenderDevice.value !== renderDevice.value)) ||
+        gpuContainerConfigChanged ||
         shareFolder.value !== origShareFolder.value ||
         sharedFolderPath.value !== origSharedFolderPath.value ||
         autoStartContainer.value !== origAutoStartContainer.value;
@@ -847,14 +869,31 @@ async function toggleExperimentalFeatures() {
 }
 
 // Watch for when shared folder is enabled and set default path
-watch(shareFolder, (newValue) => {
+watch(shareFolder, newValue => {
     if (newValue && !sharedFolderPath.value) {
         sharedFolderPath.value = os.homedir();
     }
 });
 
+async function refreshNvidiaContainerSupport() {
+    const sequence = ++nvidiaSupportCheckSequence;
+    const device = selectedGpu.value;
+    nvidiaContainerSupportAvailable.value = false;
+
+    if (!shouldCheckNvidiaContainerSupport(gpuEnabled.value, device) || !device?.nvidiaUuid) {
+        return;
+    }
+
+    const available = await hasNvidiaContainerSupport(device.nvidiaUuid);
+    if (sequence === nvidiaSupportCheckSequence) nvidiaContainerSupportAvailable.value = available;
+}
+
 watch(renderDevice, () => {
     gpuVramGB.value = Math.min(gpuVramGB.value, gpuVramMaxGB.value);
+});
+
+watch([gpuEnabled, selectedGpu], () => {
+    void refreshNvidiaContainerSupport();
 });
 </script>
 

--- a/src/renderer/views/SetupUI.vue
+++ b/src/renderer/views/SetupUI.vue
@@ -122,13 +122,16 @@
                                 </div>
                                 installed
                                 <a
-                                    :href="containerRuntime === ContainerRuntimes.PODMAN
-                                        ? 'https://podman.io/getting-started/installation'
-                                        : 'https://docs.docker.com/engine/install/'"
+                                    :href="
+                                        containerRuntime === ContainerRuntimes.PODMAN
+                                            ? 'https://podman.io/getting-started/installation'
+                                            : 'https://docs.docker.com/engine/install/'
+                                    "
                                     @click="openAnchorLink"
                                     target="_blank"
                                     class="text-violet-400 hover:underline ml-1"
-                                >How?</a>
+                                    >How?</a
+                                >
                             </li>
 
                             <!-- Docker Specific Requirements -->
@@ -629,8 +632,8 @@
                     <div v-if="currentStep.id === StepID.GPU_CONFIG" class="step-block">
                         <h1 class="text-3xl font-semibold">GPU Acceleration</h1>
                         <p class="text-lg text-gray-400">
-                            Enable the experimental Helios graphics driver to accelerate Windows with your GPU.
-                            Helios currently supports Vulkan, DirectX 11, OpenGL and OpenCL. This currently requires Docker.
+                            Enable the experimental Helios graphics driver to accelerate Windows with your GPU. Helios
+                            currently supports Vulkan, DirectX 11, OpenGL and OpenCL. This currently requires Docker.
                         </p>
 
                         <x-checkbox
@@ -688,6 +691,9 @@
                                             : "shared GPU memory"
                                     }}
                                 </p>
+                                <p v-if="nvidiaGpuError" class="text-sm text-red-400 mt-2">
+                                    {{ nvidiaGpuError }}
+                                </p>
                             </div>
 
                             <div>
@@ -713,7 +719,7 @@
                             <x-button
                                 toggled
                                 class="px-6"
-                                :disabled="gpuEnabled && !renderDevice"
+                                :disabled="gpuEnabled && (!renderDevice || !!nvidiaGpuError)"
                                 @click="currentStepIdx++"
                             >
                                 Next
@@ -725,21 +731,17 @@
                     <div v-if="currentStep.id === StepID.SHOULD_SHARE_HOME_FOLDER" class="step-block">
                         <h1 class="text-3xl font-semibold">Folder Sharing</h1>
                         <p class="text-lg text-gray-400">
-                            WinBoat allows you to share a folder from your Linux system with the Windows virtual machine.
-                            You can choose whether to enable this feature and select which folder to share.
+                            WinBoat allows you to share a folder from your Linux system with the Windows virtual
+                            machine. You can choose whether to enable this feature and select which folder to share.
                         </p>
                         <p class="text-lg text-gray-400">
                             <b>⚠️ WARNING:</b>
-                            Sharing a folder exposes your Linux files to Windows-specific malware and viruses.
-                            Only enable this feature if you understand the risks involved. Always be careful with the
-                            files you download and open in Windows.
+                            Sharing a folder exposes your Linux files to Windows-specific malware and viruses. Only
+                            enable this feature if you understand the risks involved. Always be careful with the files
+                            you download and open in Windows.
                         </p>
 
-                        <x-checkbox
-                            class="my-4"
-                            @toggle="folderSharing = !folderSharing"
-                            :toggled="folderSharing"
-                        >
+                        <x-checkbox class="my-4" @toggle="folderSharing = !folderSharing" :toggled="folderSharing">
                             <x-label><strong>Enable folder sharing</strong></x-label>
                             <x-label class="text-gray-400">
                                 By checking this box, you acknowledge the risks mentioned above
@@ -836,7 +838,9 @@
                             </div>
                             <div class="flex flex-col min-w-0">
                                 <span class="text-sm text-gray-400">Install Location</span>
-                                <span class="text-base text-white truncate" :title="installFolder">{{ installFolder }}</span>
+                                <span class="text-base text-white truncate" :title="installFolder">{{
+                                    installFolder
+                                }}</span>
                             </div>
                         </div>
 
@@ -867,11 +871,14 @@
                             <span v-else>
                                 over at
                                 <div
-                                    style="animation-duration: 3s!important;"
+                                    style="animation-duration: 3s !important"
                                     class="ml-1 inline-block relative text-transparent rounded-md bg-neutral-700 animate-pulse select-none"
                                 >
                                     in your browser
-                                    <Icon icon="eos-icons:three-dots-loading" class="pointer-events-none absolute top-0 left-[50%] size-16 text-violet-400 -translate-x-[50%] -translate-y-[27.5%]"></Icon>
+                                    <Icon
+                                        icon="eos-icons:three-dots-loading"
+                                        class="pointer-events-none absolute top-0 left-[50%] size-16 text-violet-400 -translate-x-[50%] -translate-y-[27.5%]"
+                                    ></Icon>
                                 </div>
                             </span>
                         </p>
@@ -960,7 +967,13 @@ import license from "../assets/LICENSE.txt?raw";
 import { ContainerRuntimes, getContainerSpecs, type ContainerSpecs } from "../lib/containers/common";
 import { WinboatConfig } from "../lib/config";
 import { guestServerOemDir } from "../utils/guestServer";
-import { getGpuVramMaxGB, getRenderDevices, type RenderDevice } from "../lib/gpu";
+import {
+    getGpuVramMaxGB,
+    getRenderDevices,
+    hasNvidiaContainerSupport,
+    shouldCheckNvidiaContainerSupport,
+    type RenderDevice,
+} from "../lib/gpu";
 
 const path: typeof import("path") = require("node:path");
 const electron: typeof import("electron") = require("electron").remote || require("@electron/remote");
@@ -1074,8 +1087,19 @@ const gpuVramGB = ref(DEFAULT_GPU_VRAM_GB);
 const renderDevices = ref<RenderDevice[]>([]);
 const renderDevice = ref("");
 const heliosAvailable = ref(false);
+const nvidiaContainerSupportAvailable = ref(false);
 const selectedGpu = computed(() => renderDevices.value.find(device => device.path === renderDevice.value));
 const gpuVramMaxGB = computed(() => getGpuVramMaxGB(selectedGpu.value?.vramGB));
+const nvidiaGpuError = computed(() => {
+    if (!shouldCheckNvidiaContainerSupport(gpuEnabled.value, selectedGpu.value)) return "";
+    if (!selectedGpu.value?.nvidiaUuid) {
+        return "WinBoat could not map this render node to an NVIDIA GPU through nvidia-smi.";
+    }
+    if (!nvidiaContainerSupportAvailable.value) {
+        return "NVIDIA Container Toolkit is not exposing this GPU to Docker through a runtime or CDI.";
+    }
+    return "";
+});
 const username = ref("winboat");
 const password = ref("");
 const confirmPassword = ref("");
@@ -1089,6 +1113,7 @@ const checkingPrerequisites = ref(false);
 const prerequisiteRefreshSequence = ref(0);
 let prerequisiteInterval: NodeJS.Timeout | null = null;
 let prerequisiteRefreshQueued = false;
+let nvidiaSupportCheckSequence = 0;
 // These are the install steps where the container is actually up and running
 const linkableInstallSteps = [
     InstallStates.MONITORING_PREINSTALL,
@@ -1139,7 +1164,7 @@ watch(currentStep, step => {
 });
 
 // Watch for when folder sharing is enabled and set default path
-watch(folderSharing, (newValue) => {
+watch(folderSharing, newValue => {
     if (newValue && !sharedFolderPath.value) {
         sharedFolderPath.value = os.homedir();
     }
@@ -1188,8 +1213,25 @@ function handleContainerRuntimeChange(e: CustomEvent<{ newValue: ContainerRuntim
     void refreshPrerequisites();
 }
 
+async function refreshNvidiaContainerSupport() {
+    const sequence = ++nvidiaSupportCheckSequence;
+    const device = selectedGpu.value;
+    nvidiaContainerSupportAvailable.value = false;
+
+    if (!shouldCheckNvidiaContainerSupport(gpuEnabled.value, device) || !device?.nvidiaUuid) {
+        return;
+    }
+
+    const available = await hasNvidiaContainerSupport(device.nvidiaUuid);
+    if (sequence === nvidiaSupportCheckSequence) nvidiaContainerSupportAvailable.value = available;
+}
+
 watch(renderDevice, () => {
     gpuVramGB.value = Math.min(gpuVramGB.value, gpuVramMaxGB.value);
+});
+
+watch([gpuEnabled, selectedGpu], () => {
+    void refreshNvidiaContainerSupport();
 });
 
 function continueFromPrerequisites() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,19 @@ export type ComposeConfig = {
             restart: string;
             volumes: string[];
             devices: string[];
+            deploy?: {
+                resources?: {
+                    reservations?: {
+                        devices?: {
+                            driver?: string;
+                            device_ids?: string[];
+                            count?: number | "all";
+                            capabilities: string[];
+                            options?: Record<string, string>;
+                        }[];
+                    };
+                };
+            };
         };
     };
 };

--- a/tests/gpu-container.test.ts
+++ b/tests/gpu-container.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import type { ComposeConfig } from "../src/types";
+import { configureGpuContainer, gpuContainerConfigNeedsUpdate } from "../src/renderer/lib/gpu-container";
+import {
+    nvidiaCdiSpecProvidesGpu,
+    shouldCheckNvidiaContainerSupport,
+    type RenderDevice,
+} from "../src/renderer/lib/gpu";
+
+function makeService(): ComposeConfig["services"]["windows"] {
+    return {
+        image: "example.invalid/windows",
+        container_name: "WinBoat",
+        environment: {
+            VERSION: "11",
+            RAM_SIZE: "4G",
+            CPU_CORES: "4",
+            DISK_SIZE: "64G",
+            USERNAME: "winboat",
+            PASSWORD: "password",
+            HOME: "/home/user",
+            LANGUAGE: "English",
+            ARGUMENTS: "",
+            HOST_PORTS: "",
+        },
+        ports: [],
+        cap_add: [],
+        stop_grace_period: "120s",
+        restart: "no",
+        volumes: [],
+        devices: [],
+    };
+}
+
+const nvidiaDevice: RenderDevice = {
+    path: "/dev/dri/renderD128",
+    name: "NVIDIA GPU",
+    driver: "nvidia",
+    nvidiaUuid: "GPU-11111111-2222-3333-4444-555555555555",
+};
+
+const intelDevice: RenderDevice = {
+    path: "/dev/dri/renderD129",
+    name: "Intel GPU",
+    driver: "i915",
+};
+
+describe("GPU container configuration", () => {
+    it("requests the exact NVIDIA GPU and graphics driver libraries", () => {
+        const service = makeService();
+
+        configureGpuContainer(service, nvidiaDevice);
+
+        expect(service.environment.NVIDIA_DRIVER_CAPABILITIES).toBe("graphics");
+        expect(service.environment).toMatchObject({
+            __NV_PRIME_RENDER_OFFLOAD: "1",
+            __EGL_VENDOR_LIBRARY_FILENAMES: "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+            __GLX_VENDOR_LIBRARY_NAME: "nvidia",
+            __VK_LAYER_NV_optimus: "NVIDIA_only",
+            VK_ICD_FILENAMES: "/etc/vulkan/icd.d/nvidia_icd.json",
+            GBM_BACKEND: "nvidia-drm",
+            GBM_BACKENDS_PATH: "/usr/lib/gbm:/usr/lib/x86_64-linux-gnu/gbm",
+        });
+        expect(service.deploy?.resources?.reservations?.devices).toEqual([
+            {
+                driver: "nvidia",
+                device_ids: [nvidiaDevice.nvidiaUuid!],
+                capabilities: ["gpu"],
+            },
+        ]);
+        expect(gpuContainerConfigNeedsUpdate(service, nvidiaDevice)).toBe(false);
+    });
+
+    it("removes NVIDIA-only settings when switching to another render device", () => {
+        const service = makeService();
+        service.deploy = {
+            resources: {
+                reservations: {
+                    devices: [{ driver: "example", count: 1, capabilities: ["gpu"] }],
+                },
+            },
+        };
+        configureGpuContainer(service, nvidiaDevice);
+
+        configureGpuContainer(service, intelDevice);
+
+        expect(service.environment.NVIDIA_DRIVER_CAPABILITIES).toBeUndefined();
+        expect(service.environment.GBM_BACKEND).toBeUndefined();
+        expect(service.environment.__EGL_VENDOR_LIBRARY_FILENAMES).toBeUndefined();
+        expect(service.environment.VK_ICD_FILENAMES).toBeUndefined();
+        expect(service.deploy?.resources?.reservations?.devices).toEqual([
+            { driver: "example", count: 1, capabilities: ["gpu"] },
+        ]);
+        expect(gpuContainerConfigNeedsUpdate(service, intelDevice)).toBe(false);
+    });
+
+    it("rejects a proprietary NVIDIA render node without an exact GPU UUID", () => {
+        const service = makeService();
+
+        expect(() => configureGpuContainer(service, { ...nvidiaDevice, nvidiaUuid: undefined })).toThrow(
+            "Could not map /dev/dri/renderD128 to an NVIDIA GPU UUID through nvidia-smi.",
+        );
+    });
+});
+
+describe("NVIDIA CDI detection", () => {
+    const cdiSpec = `
+cdiVersion: 0.6.0
+kind: nvidia.com/gpu
+devices:
+  - name: GPU-11111111-2222-3333-4444-555555555555
+  - name: GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+`;
+
+    it("recognizes the exact GPU exposed by an NVIDIA CDI spec", () => {
+        expect(nvidiaCdiSpecProvidesGpu(cdiSpec, nvidiaDevice.nvidiaUuid)).toBe(true);
+        expect(nvidiaCdiSpecProvidesGpu(cdiSpec, "GPU-missing")).toBe(false);
+    });
+
+    it("rejects another CDI kind and malformed YAML", () => {
+        expect(nvidiaCdiSpecProvidesGpu(cdiSpec.replace("nvidia.com/gpu", "vendor.example/gpu"))).toBe(false);
+        expect(nvidiaCdiSpecProvidesGpu("kind: [")).toBe(false);
+    });
+});
+
+describe("NVIDIA Container Toolkit gate", () => {
+    it("checks only when GPU acceleration and a proprietary NVIDIA device are both selected", () => {
+        expect(shouldCheckNvidiaContainerSupport(true, nvidiaDevice)).toBe(true);
+        expect(shouldCheckNvidiaContainerSupport(false, nvidiaDevice)).toBe(false);
+        expect(shouldCheckNvidiaContainerSupport(true, intelDevice)).toBe(false);
+    });
+});


### PR DESCRIPTION
Map render nodes to exact NVIDIA UUIDs, require runtime or CDI support, and keep Vulkan, EGL, and GBM on the NVIDIA provider.

depends on https://github.com/winboat-org/helios-windows/pull/1